### PR TITLE
MRG: make submodule .git directory for versioneer

### DIFF
--- a/common_utils.sh
+++ b/common_utils.sh
@@ -256,8 +256,9 @@ function fill_submodule {
     [ -d "$git_loc" ] && return
     # Need to recreate .git directory for submodule
     local origin_url=$(cd "$repo_dir" && git config --get remote.origin.url)
-    git clone --recursive "$repo_dir" "${repo_dir}-copy"
+    local repo_copy="$repo_dir-$RANDOM"
+    git clone --recursive "$repo_dir" "$repo_copy"
     rm -rf "$repo_dir"
-    mv "${repo_dir}-copy" "$repo_dir"
+    mv "${repo_copy}" "$repo_dir"
     (cd "$repo_dir" && git remote set-url origin $origin_url)
 }

--- a/common_utils.sh
+++ b/common_utils.sh
@@ -256,8 +256,8 @@ function fill_submodule {
     [ -d "$git_loc" ] && return
     # Need to recreate .git directory for submodule
     local origin_url=$(cd "$repo_dir" && git config --get remote.origin.url)
-    git clone --recursive --mirror "$repo_dir" "$repo_dir/.git-full"
-    rm "$git_loc"
-    mv "$repo_dir/.git-full" "$git_loc"
+    git clone --recursive "$repo_dir" "${repo_dir}-copy"
+    rm -rf "$repo_dir"
+    mv "${repo_dir}-copy" "$repo_dir"
     (cd "$repo_dir" && git remote set-url origin $origin_url)
 }

--- a/common_utils.sh
+++ b/common_utils.sh
@@ -112,6 +112,11 @@ function clean_code {
     local build_commit=${2:-$BUILD_COMMIT}
     [ -z "$repo_dir" ] && echo "repo_dir not defined" && exit 1
     [ -z "$build_commit" ] && echo "build_commit not defined" && exit 1
+    # The package $repo_dir may be a submodule. git submodules do not
+    # have a .git directory. If $repo_dir is copied around, tools like
+    # Versioneer which require that it be a git repository are unable
+    # to determine the version.  Give submodule proper git directory
+    fill_submodule "$repo_dir"
     (cd $repo_dir \
         && git fetch origin \
         && git checkout $build_commit \
@@ -238,4 +243,21 @@ function install_run {
     install_wheel
     mkdir tmp_for_test
     (cd tmp_for_test && run_tests)
+}
+
+function fill_submodule {
+    # Restores .git directory to submodule, if necessary
+    # See:
+    # http://stackoverflow.com/questions/41776331/is-there-a-way-to-reconstruct-a-git-directory-for-a-submodule
+    local repo_dir="$1"
+    [ -z "$repo_dir" ] && echo "repo_dir not defined" && exit 1
+    local git_loc="$repo_dir/.git"
+    # For ordinary submodule, .git is a file.
+    [ -d "$git_loc" ] && return
+    # Need to recreate .git directory for submodule
+    local origin_url=$(cd "$repo_dir" && git config --get remote.origin.url)
+    git clone --recursive --mirror "$repo_dir" "$repo_dir/.git-full"
+    rm "$git_loc"
+    mv "$repo_dir/.git-full" "$git_loc"
+    (cd "$repo_dir" && git remote set-url origin $origin_url)
 }

--- a/tests/test_fill_submodule.sh
+++ b/tests/test_fill_submodule.sh
@@ -27,6 +27,8 @@ cd project
 [ "$(git log --format="%s")" == "first project" ] || ingest "bad after filling"
 [ -d .git ] || ingest "expecting .git to be a directory"
 [ "$(git config --get remote.origin.url)" == "$remote_url" ] || ingest "bad remote"
+# Check we can do a checkout
+git checkout master
 cd ..
 # Intervene again (has .git directory now)
 fill_submodule project

--- a/tests/test_fill_submodule.sh
+++ b/tests/test_fill_submodule.sh
@@ -8,7 +8,8 @@ mkdir project
     echo "Interesting!" > README.txt &&
     git add README.txt &&
     local_author &&
-    git commit -m "first project")
+    git commit -m "first project" &&
+    git tag first-commit)
 mkdir superproject
 cd superproject
 git init
@@ -27,8 +28,10 @@ cd project
 [ "$(git log --format="%s")" == "first project" ] || ingest "bad after filling"
 [ -d .git ] || ingest "expecting .git to be a directory"
 [ "$(git config --get remote.origin.url)" == "$remote_url" ] || ingest "bad remote"
-# Check we can do a checkout
+# Check we can do a checkout of a branch
 git checkout master
+# Checkout a tag
+git checkout first-commit
 cd ..
 # Intervene again (has .git directory now)
 fill_submodule project

--- a/tests/test_fill_submodule.sh
+++ b/tests/test_fill_submodule.sh
@@ -1,0 +1,40 @@
+# Test fill_submodule function
+current_wd=$PWD
+
+rm_mkdir tmp_repos
+cd tmp_repos
+mkdir project
+(cd project && git init &&
+    echo "Interesting!" > README.txt &&
+    git add README.txt &&
+    local_author &&
+    git commit -m "first project")
+mkdir superproject
+cd superproject
+git init
+git submodule add ../project
+local_author
+git commit -m "first superproject"
+# Check the submodule is working correctly before intervention
+cd project
+remote_url=$(git config --get remote.origin.url)
+[ "$(git log --format="%s")" == "first project" ] || ingest "bad submodule"
+[ -f .git ] || ingest "expecting .git to be a file"
+cd ..
+# Intervene
+fill_submodule project
+cd project
+[ "$(git log --format="%s")" == "first project" ] || ingest "bad after filling"
+[ -d .git ] || ingest "expecting .git to be a directory"
+[ "$(git config --get remote.origin.url)" == "$remote_url" ] || ingest "bad remote"
+cd ..
+# Intervene again (has .git directory now)
+fill_submodule project
+cd project
+[ "$(git log --format="%s")" == "first project" ] || ingest "bad after refilling"
+[ -d .git ] || ingest "expecting .git to be a directory"
+[ "$(git config --get remote.origin.url)" == "$remote_url" ] || ingest "bad remote"
+cd ..
+
+cd "$current_wd"
+rm -rf tmp_repos

--- a/tests/test_multibuild.sh
+++ b/tests/test_multibuild.sh
@@ -3,6 +3,7 @@ source common_utils.sh
 source tests/utils.sh
 
 source tests/test_common_utils.sh
+source tests/test_fill_submodule.sh
 if [ -n "$IS_OSX" ]; then
     source osx_utils.sh
     get_macpython_environment $PYTHON_VERSION $VENV

--- a/tests/utils.sh
+++ b/tests/utils.sh
@@ -10,3 +10,9 @@ function ingest {
 function barf {
     [ "$RET" == 0 ] || exit 1
 }
+
+function local_author {
+    # Run in git repository to set commit author
+    git config user.email "my@noble.self"
+    git config user.name "Noble Self"
+}


### PR DESCRIPTION
pip will copy the directory it installs from before running the install
/ wheel build.  If the directory is a submodule, then the copy breaks
the connection with the containing project, so git commands to get the
version will fail.

Fix is to re-create the .git directory for submodules.

Version of fix in https://github.com/matthew-brett/multibuild/pull/12
with thanks to Hassan Kibirige for doing the hard work of diagnosis and finding the general solution.