### PR TITLE
[library_builders] allow to override tar.gz extension in build_simple

### DIFF
--- a/library_builders.sh
+++ b/library_builders.sh
@@ -51,12 +51,13 @@ function build_simple {
     local name=$1
     local version=$2
     local url=$3
+    local ext=${4:-tar.gz}
     if [ -e "${name}-stamp" ]; then
         return
     fi
     local name_version="${name}-${version}"
-    local targz=${name_version}.tar.gz
-    fetch_unpack $url/$targz
+    local archive=${name_version}.${ext}
+    fetch_unpack $url/$archive
     (cd $name_version \
         && ./configure --prefix=$BUILD_PREFIX \
         && make \


### PR DESCRIPTION
Some libraries use 'tar.bz2' instead of 'tar.gz' as source archive format.
This patch allows to pass a fourth argument to `build_simple` function to specify an alternative extension to the default `tar.gz`.

The `untar` function in common_utils.sh, used by `fetch_unpack`, already supports the following archive formats: tar, gz, bz2, zip and xz.
