### PR TITLE
Changed openjpeg archive prefix for versions newer than 2.1.0

### DIFF
--- a/library_builders.sh
+++ b/library_builders.sh
@@ -144,7 +144,11 @@ function build_openjpeg {
     build_tiff
     build_lcms2
     local cmake=$(get_cmake)
-    fetch_unpack https://github.com/uclouvain/openjpeg/archive/version.${OPENJPEG_VERSION}.tar.gz
+    local archive_prefix="v"
+    if [ $(lex_ver $OPENJPEG_VERSION) -lt $(lex_ver 2.1.1) ]; then
+        archive_prefix="version."
+    fi
+    fetch_unpack https://github.com/uclouvain/openjpeg/archive/${archive_prefix}${OPENJPEG_VERSION}.tar.gz
     (cd openjpeg-version.${OPENJPEG_VERSION} \
         && $cmake -DCMAKE_INSTALL_PREFIX=$BUILD_PREFIX . \
         && make install)


### PR DESCRIPTION
For [2.1.0](https://github.com/uclouvain/openjpeg/releases/tag/version.2.1) and prior, [the archives started with 'version.'](https://github.com/uclouvain/openjpeg/archive/version.2.1.tar.gz).

Since then, [they start with 'v'](https://github.com/uclouvain/openjpeg/archive/v2.1.1.tar.gz) - https://github.com/uclouvain/openjpeg/releases