### PR TITLE
libraries: allow build_simple with configure args

### DIFF
--- a/library_builders.sh
+++ b/library_builders.sh
@@ -170,16 +170,12 @@ function build_xz {
 }
 
 function build_libwebp {
-    if [ -e libwebp-stamp ]; then return; fi
     build_libpng
     build_tiff
     build_giflib
-    fetch_unpack https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-${LIBWEBP_VERSION}.tar.gz
-    (cd libwebp-${LIBWEBP_VERSION} && \
-        ./configure --enable-libwebpmux --enable-libwebpdemux --prefix=$BUILD_PREFIX \
-        && make \
-        && make install)
-    touch libwebp-stamp
+    build_simple libwebp $LIBWEBP_VERSION \
+        https://storage.googleapis.com/downloads.webmproject.org/releases/webp/ \
+        --enable-libwebpmux --enable-libwebpdemux 
 }
 
 function build_freetype {
@@ -194,15 +190,10 @@ function build_libyaml {
 
 function build_szip {
     # Build szip without encoding (patent restrictions)
-    if [ -e szip-stamp ]; then return; fi
     build_zlib
-    local szip_url=https://www.hdfgroup.org/ftp/lib-external/szip/
-    fetch_unpack ${szip_url}/$SZIP_VERSION/src/szip-$SZIP_VERSION.tar.gz
-    (cd szip-$SZIP_VERSION \
-        && ./configure --enable-encoding=no --prefix=$BUILD_PREFIX \
-        && make \
-        && make install)
-    touch szip-stamp
+    build_simple szip $SZIP_VERSION \
+        https://www.hdfgroup.org/ftp/lib-external/szip/ \
+        --enable-encoding=no
 }
 
 function build_hdf5 {

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -49,6 +49,8 @@ if [ -n "$IS_OSX" ]; then
 fi
 
 function build_simple {
+    # Example: build_simple libpng $LIBPNG_VERSION
+    #   http://download.sourceforge.net/libpng tar.gz --additional --configure --arguments
     local name=$1
     local version=$2
     local url=$3

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -52,6 +52,7 @@ function build_simple {
     local name=$1
     local version=$2
     local url=$3
+    local configure_args=${@:4}
     if [ -e "${name}-stamp" ]; then
         return
     fi
@@ -59,7 +60,7 @@ function build_simple {
     local targz=${name_version}.tar.gz
     fetch_unpack $url/$targz
     (cd $name_version \
-        && ./configure --prefix=$BUILD_PREFIX \
+        && ./configure --prefix=$BUILD_PREFIX $configure_args \
         && make \
         && make install)
     touch "${name}-stamp"

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -60,10 +60,6 @@ function build_simple {
     local url=$3
     local ext=${4:-tar.gz}
     local configure_args=${@:5}
-    if [[ $ext == --* ]]; then
-        configure_args="$ext $configure_args"
-        ext="tar.gz"
-    fi
     if [ -e "${name}-stamp" ]; then
         return
     fi
@@ -186,7 +182,7 @@ function build_libwebp {
     build_tiff
     build_giflib
     build_simple libwebp $LIBWEBP_VERSION \
-        https://storage.googleapis.com/downloads.webmproject.org/releases/webp/ \
+        https://storage.googleapis.com/downloads.webmproject.org/releases/webp/ tar.gz \
         --enable-libwebpmux --enable-libwebpdemux 
 }
 
@@ -204,7 +200,7 @@ function build_szip {
     # Build szip without encoding (patent restrictions)
     build_zlib
     build_simple szip $SZIP_VERSION \
-        https://www.hdfgroup.org/ftp/lib-external/szip/ \
+        https://www.hdfgroup.org/ftp/lib-external/szip/ tar.gz \
         --enable-encoding=no
 }
 

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -59,7 +59,7 @@ function build_simple {
     local configure_args=${@:5}
     if [[ $ext == --* ]]; then
         configure_args="$ext $configure_args"
-        ext=".tar.gz"
+        ext="tar.gz"
     fi
     if [ -e "${name}-stamp" ]; then
         return

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -49,8 +49,9 @@ if [ -n "$IS_OSX" ]; then
 fi
 
 function build_simple {
-    # Example: build_simple libpng $LIBPNG_VERSION
-    #   http://download.sourceforge.net/libpng tar.gz --additional --configure --arguments
+    # Example: build_simple libpng $LIBPNG_VERSION \
+    #               http://download.sourceforge.net/libpng tar.gz \
+    #               --additional --configure --arguments
     local name=$1
     local version=$2
     local url=$3
@@ -176,7 +177,7 @@ function build_libwebp {
     build_tiff
     build_giflib
     build_simple libwebp $LIBWEBP_VERSION \
-        https://storage.googleapis.com/downloads.webmproject.org/releases/webp/ \
+        https://storage.googleapis.com/downloads.webmproject.org/releases/webp/ tar.gz \
         --enable-libwebpmux --enable-libwebpdemux 
 }
 
@@ -194,7 +195,7 @@ function build_szip {
     # Build szip without encoding (patent restrictions)
     build_zlib
     build_simple szip $SZIP_VERSION \
-        https://www.hdfgroup.org/ftp/lib-external/szip/ \
+        https://www.hdfgroup.org/ftp/lib-external/szip/ tar.gz \
         --enable-encoding=no
 }
 

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -57,6 +57,10 @@ function build_simple {
     local url=$3
     local ext=${4:-tar.gz}
     local configure_args=${@:5}
+    if [[ $ext == --* ]]; then
+        configure_args="$ext $configure_args"
+        ext=".tar.gz"
+    fi
     if [ -e "${name}-stamp" ]; then
         return
     fi
@@ -177,7 +181,7 @@ function build_libwebp {
     build_tiff
     build_giflib
     build_simple libwebp $LIBWEBP_VERSION \
-        https://storage.googleapis.com/downloads.webmproject.org/releases/webp/ tar.gz \
+        https://storage.googleapis.com/downloads.webmproject.org/releases/webp/ \
         --enable-libwebpmux --enable-libwebpdemux 
 }
 
@@ -195,7 +199,7 @@ function build_szip {
     # Build szip without encoding (patent restrictions)
     build_zlib
     build_simple szip $SZIP_VERSION \
-        https://www.hdfgroup.org/ftp/lib-external/szip/ tar.gz \
+        https://www.hdfgroup.org/ftp/lib-external/szip/ \
         --enable-encoding=no
 }
 

--- a/tests/test_library_builders.sh
+++ b/tests/test_library_builders.sh
@@ -11,6 +11,6 @@ function suppress {
     /bin/rm /tmp/suppress.out
 }
 
-# suppress build_openssl
-build_libwebp
-build_szip
+suppress build_openssl
+suppress build_libwebp
+suppress build_szip

--- a/tests/test_library_builders.sh
+++ b/tests/test_library_builders.sh
@@ -6,9 +6,9 @@ source library_builders.sh
 
 function suppress {
     # Suppress the output of a bash command unless it fails
-    rm --force $TMPDIR/suppress.out 2> /dev/null
-    $* 2>&1 > $TMPDIR/suppress.out || cat $TMPDIR/suppress.out
-    rm $TMPDIR/suppress.out
+    rm --force $HOME/suppress.out 2> /dev/null
+    $* 2>&1 > $HOME/suppress.out || cat $HOME/suppress.out
+    rm $HOME/suppress.out
 }
 
 suppress build_openssl

--- a/tests/test_library_builders.sh
+++ b/tests/test_library_builders.sh
@@ -4,4 +4,13 @@ export BUILD_PREFIX="${PWD}/builds"
 rm_mkdir $BUILD_PREFIX
 source library_builders.sh
 
-build_openssl
+function surpress {
+    # Suppress the output of a bash command unless it fails
+    /bin/rm --force /tmp/surpress.out 2> /dev/null
+    $* 2>&1 > /tmp/surpress.out || cat /tmp/surpress.out
+    /bin/rm /tmp/surpress.out
+}
+
+suppress build_openssl
+suppress build_libwebp
+suppress build_szip

--- a/tests/test_library_builders.sh
+++ b/tests/test_library_builders.sh
@@ -8,7 +8,7 @@ set -e -x
 
 function suppress {
     # Suppress the output of a bash command unless it fails
-    rm --force $HOME/suppress.out 2> /dev/null
+    rm --force $HOME/suppress.out 2> /dev/null || true
     $* 2>&1 > $HOME/suppress.out || cat $HOME/suppress.out
     rm $HOME/suppress.out
 }

--- a/tests/test_library_builders.sh
+++ b/tests/test_library_builders.sh
@@ -11,6 +11,6 @@ function suppress {
     /bin/rm /tmp/suppress.out
 }
 
-suppress build_openssl
-suppress build_libwebp
-suppress build_szip
+# suppress build_openssl
+build_libwebp
+build_szip

--- a/tests/test_library_builders.sh
+++ b/tests/test_library_builders.sh
@@ -6,9 +6,9 @@ source library_builders.sh
 
 function suppress {
     # Suppress the output of a bash command unless it fails
-    /bin/rm --force /tmp/suppress.out 2> /dev/null
-    $* 2>&1 > /tmp/suppress.out || cat /tmp/suppress.out
-    /bin/rm /tmp/suppress.out
+    rm --force $TMPDIR/suppress.out 2> /dev/null
+    $* 2>&1 > $TMPDIR/suppress.out || cat $TMPDIR/suppress.out
+    rm $TMPDIR/suppress.out
 }
 
 suppress build_openssl

--- a/tests/test_library_builders.sh
+++ b/tests/test_library_builders.sh
@@ -4,11 +4,11 @@ export BUILD_PREFIX="${PWD}/builds"
 rm_mkdir $BUILD_PREFIX
 source library_builders.sh
 
-function surpress {
+function suppress {
     # Suppress the output of a bash command unless it fails
-    /bin/rm --force /tmp/surpress.out 2> /dev/null
-    $* 2>&1 > /tmp/surpress.out || cat /tmp/surpress.out
-    /bin/rm /tmp/surpress.out
+    /bin/rm --force /tmp/suppress.out 2> /dev/null
+    $* 2>&1 > /tmp/suppress.out || cat /tmp/suppress.out
+    /bin/rm /tmp/suppress.out
 }
 
 suppress build_openssl

--- a/tests/test_library_builders.sh
+++ b/tests/test_library_builders.sh
@@ -4,7 +4,7 @@ export BUILD_PREFIX="${PWD}/builds"
 rm_mkdir $BUILD_PREFIX
 source library_builders.sh
 
-set -e -x
+# set -e -x
 
 function suppress {
     # Suppress the output of a bash command unless it fails

--- a/tests/test_library_builders.sh
+++ b/tests/test_library_builders.sh
@@ -8,7 +8,7 @@ set -e -x
 
 function suppress {
     # Suppress the output of a bash command unless it fails
-    rm --force $HOME/suppress.out 2> /dev/null || true
+    rm -f $HOME/suppress.out 2> /dev/null || true
     $* 2>&1 > $HOME/suppress.out || cat $HOME/suppress.out
     rm $HOME/suppress.out
 }

--- a/tests/test_library_builders.sh
+++ b/tests/test_library_builders.sh
@@ -4,6 +4,8 @@ export BUILD_PREFIX="${PWD}/builds"
 rm_mkdir $BUILD_PREFIX
 source library_builders.sh
 
+set -e -x
+
 function suppress {
     # Suppress the output of a bash command unless it fails
     rm --force $HOME/suppress.out 2> /dev/null


### PR DESCRIPTION
Here, we add the option to pass arbitrary configure arguments to build-simple. In addition, we add a function that improves the testing of library builders by reducing the verbosity of testing unless there are test failures. We then test our new functions by adding them to the build_libraries tests.