### PR TITLE
Building libpng with new zlib

### DIFF
--- a/library_builders.sh
+++ b/library_builders.sh
@@ -131,7 +131,13 @@ function build_jpeg {
 
 function build_libpng {
     build_zlib
-    build_simple libpng $LIBPNG_VERSION http://download.sourceforge.net/libpng
+    if [ -e libpng-stamp ]; then return; fi
+    fetch_unpack http://download.sourceforge.net/libpng/libpng-${LIBPNG_VERSION}.tar.gz
+    (cd libpng-${LIBPNG_VERSION} \
+        && ./configure --prefix=$BUILD_PREFIX LDFLAGS="-L$BUILD_PREFIX/lib" \
+        && make \
+        && make install)
+    touch "${name}-stamp"
 }
 
 function build_bzip2 {

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -131,13 +131,8 @@ function build_jpeg {
 
 function build_libpng {
     build_zlib
-    if [ -e libpng-stamp ]; then return; fi
-    fetch_unpack http://download.sourceforge.net/libpng/libpng-${LIBPNG_VERSION}.tar.gz
-    (cd libpng-${LIBPNG_VERSION} \
-        && ./configure --prefix=$BUILD_PREFIX LDFLAGS="-L$BUILD_PREFIX/lib" \
-        && make \
-        && make install)
-    touch "${name}-stamp"
+    build_simple libpng $LIBPNG_VERSION http://download.sourceforge.net/libpng tar.gz
+        LDFLAGS="-L$BUILD_PREFIX/lib"
 }
 
 function build_bzip2 {

--- a/tests/test_library_builders.sh
+++ b/tests/test_library_builders.sh
@@ -14,6 +14,7 @@ function suppress {
 }
 
 suppress build_openssl
+suppress build_libpng
 suppress build_libwebp
 suppress build_szip
 suppress build_swig


### PR DESCRIPTION
This PR adds a function that is intended to be build_libpng, but using the zlib generated by build_new_zlib. I imagine you'll have a better idea, but hopefully this is enough to start things going.

If you're interested, the reason that I'm creating this PR is because [this version of pillow-wheels config.sh](https://github.com/radarhere/pillow-wheels/blob/libpng1632_test/config.sh) [fails in Travis](https://travis-ci.org/radarhere/pillow-wheels/builds/289411066), but [this version of pillow-wheels config.sh](https://github.com/radarhere/pillow-wheels/blob/libpng1632_fix/config.sh) [passes in Travis](https://travis-ci.org/radarhere/pillow-wheels/builds/289411093).