### PR TITLE
Update URL for Python 2.x Miniconda

### DIFF
--- a/ci/appveyor/install.ps1
+++ b/ci/appveyor/install.ps1
@@ -10,7 +10,7 @@ function DownloadMiniconda ($python_version, $platform_suffix) {
     if ($python_version -gt "3") {
         $filename = "Miniconda3-latest-Windows-" + $platform_suffix + ".exe"
     } else {
-        $filename = "Miniconda-latest-Windows-" + $platform_suffix + ".exe"
+        $filename = "Miniconda2-latest-Windows-" + $platform_suffix + ".exe"
     }
     $url = $MINICONDA_URL + $filename
 


### PR DESCRIPTION
The URL for Python 2.x miniconda has been changed to ``http://repo.continuum.io/miniconda/Miniconda2-latest-Windows-x86.exe``. As a result, my Windows builds ended up crashing:
```
rd /s /q %PYTHON%
.\\multibuild\\ci\\appveyor\\install.ps1
Installing Python 2.7 for 32 bit architecture to C:\Miniconda
Downloading Miniconda-latest-Windows-x86.exe from http://repo.continuum.io/miniconda/Miniconda-latest-Windows-x86.exe
Exception calling "DownloadFile" with "2" argument(s): "The remote server returned an error: (404) Not Found."
At C:\projects\treelite-wheels\multibuild\ci\appveyor\install.ps1:40 char:8
+        $webclient.DownloadFile($url, $filepath)
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : WebException
```

Fix: update the URL in ``install.ps1``