### PR TITLE
Add a progress bar to pre-build

### DIFF
--- a/common_utils.sh
+++ b/common_utils.sh
@@ -365,6 +365,18 @@ function stop_progress {
     kill $MULTIBULD_PROGRESS_BAR_PID >/dev/null 2>&1
 }
 
+function print_failure {
+    cat $HOME/suppress.out 
+    exit 1
+}
+
+function suppress {
+    # Suppress the output of a bash command unless it fails
+    rm -f $HOME/suppress.out 2> /dev/null || true
+    $* 2>&1 > $HOME/suppress.out || print_failure
+    rm $HOME/suppress.out
+}
+
 function run_progress {
     # maximal_size_of_bar speed_in_seconds first_delimiter fill_chars last_delimiter
     MAX=${1:-11}

--- a/common_utils.sh
+++ b/common_utils.sh
@@ -359,17 +359,17 @@ retry () {
 MULTIBULD_PROGRESS_BAR_PID=0
 
 function start_progress {
-    run_progress &
+    if [ "$MULTIBULD_PROGRESS_BAR_PID" -ne 0 ]; then return; fi
+
+    _run_progress &
     MULTIBULD_PROGRESS_BAR_PID=$!
 }
 
 function stop_progress {
-    kill $MULTIBULD_PROGRESS_BAR_PID >/dev/null 2>&1
-}
+    if [ "$MULTIBULD_PROGRESS_BAR_PID" -eq 0 ]; then return; fi
 
-function print_failure {
-    cat $HOME/suppress.out 
-    exit 1
+    kill $MULTIBULD_PROGRESS_BAR_PID >/dev/null 2>&1
+    MULTIBULD_PROGRESS_BAR_PID=0
 }
 
 function suppress {
@@ -379,7 +379,12 @@ function suppress {
     rm $HOME/suppress.out
 }
 
-function run_progress {
+function _print_failure {
+    cat $HOME/suppress.out 
+    exit 1
+}
+
+function _run_progress {
     # maximal_size_of_bar speed_in_seconds first_delimiter fill_chars last_delimiter
     MAX=${1:-11}
     TIME="${2:-0.08}"

--- a/common_utils.sh
+++ b/common_utils.sh
@@ -353,3 +353,56 @@ retry () {
     }
     return 0
 }
+
+MULTIBULD_PROGRESS_BAR_PID=0
+
+function start_progress {
+    run_progress &
+    MULTIBULD_PROGRESS_BAR_PID=$!
+}
+
+function stop_progress {
+    kill $MULTIBULD_PROGRESS_BAR_PID >/dev/null 2>&1
+}
+
+function run_progress {
+    # maximal_size_of_bar speed_in_seconds first_delimiter fill_chars last_delimiter
+    MAX=${1:-11}
+    TIME="${2:-0.08}"
+    TL="${3:-[}"
+    S="${4:-#####}"
+    TR="${5:-]}"
+
+    while true; do
+        R=0
+        while [ $R -lt $MAX ]; do 
+            RSP=$(($MAX - $R ))
+            if [ $RSP -gt $MAX ]; then RSP=$MAX ; fi 
+            LSP=$(($MAX - ${RSP}))
+            echo -n "$TL"
+            for l in $(seq 1 $LSP); do
+                echo -n " "
+            done
+            echo -n $S
+            for r in $(seq 1 $RSP); do
+                echo -n " "
+            done; echo -ne "$TR\r"
+            sleep $TIME ; ((R++))
+        done
+        while [ $R -ne 0 ]; do
+            RSP=$(($MAX - $R ))
+            if [ $RSP -ge $MAX ]; then RSP=$MAX ; fi 
+            LSP=$(($R + 0 )) 
+            if [ $LSP -lt 0 ]; then LSP=0 ; fi 
+            echo -n "$TL"
+            for l in $(seq 1 $R); do
+                echo -n " "
+            done
+            echo -n $S
+            for r in $(seq 1 $RSP); do
+                echo -n " "
+            done; echo -ne "$TR\r"
+            sleep $TIME; ((R--))
+        done
+    done
+}

--- a/common_utils.sh
+++ b/common_utils.sh
@@ -361,7 +361,7 @@ MULTIBULD_PROGRESS_BAR_PID=0
 function start_progress {
     if [ "$MULTIBULD_PROGRESS_BAR_PID" -ne 0 ]; then return; fi
 
-    _run_progress &
+    _run_progress 1>&2 &
     MULTIBULD_PROGRESS_BAR_PID=$!
 }
 

--- a/common_utils.sh
+++ b/common_utils.sh
@@ -375,7 +375,7 @@ function stop_progress {
 function suppress {
     # Suppress the output of a bash command unless it fails
     rm -f $HOME/suppress.out 2> /dev/null || true
-    $* 2>&1 > $HOME/suppress.out || print_failure
+    $* 2>&1 > $HOME/suppress.out || _print_failure
     rm $HOME/suppress.out
 }
 

--- a/common_utils.sh
+++ b/common_utils.sh
@@ -203,7 +203,9 @@ function build_index_wheel {
     # Discard first argument to pass remainder to pip
     shift
     local wheelhouse=$(abspath ${WHEEL_SDIR:-wheelhouse})
-    if [ -n "$(is_function "pre_build")" ]; then pre_build; fi
+    start_progress
+    if [ -n "$(is_function "pre_build")" ]; then suppress pre_build; fi
+    stop_progress
     if [ -n "$BUILD_DEPENDS" ]; then
         pip install $(pip_opts) $@ $BUILD_DEPENDS
     fi

--- a/tests/test_library_builders.sh
+++ b/tests/test_library_builders.sh
@@ -6,18 +6,6 @@ source library_builders.sh
 
 # set -e -x
 
-function print_failure {
-    cat $HOME/suppress.out 
-    exit 1
-}
-
-function suppress {
-    # Suppress the output of a bash command unless it fails
-    rm -f $HOME/suppress.out 2> /dev/null || true
-    $* 2>&1 > $HOME/suppress.out || print_failure
-    rm $HOME/suppress.out
-}
-
 if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update; fi
 
 suppress build_openssl

--- a/tests/test_library_builders.sh
+++ b/tests/test_library_builders.sh
@@ -8,9 +8,13 @@ source library_builders.sh
 
 if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update; fi
 
+start_progress
+
 suppress build_openssl
 suppress build_libpng
 suppress build_libwebp
 suppress build_szip
 suppress build_swig
 suppress build_github fredrik-johansson/arb 2.11.1
+
+stop_progress


### PR DESCRIPTION
The main reason for this is that builds can sometimes time out if the build outputs nothing for ten minutes. Some consideration is needed here before merging; I'll let the one sit open for a while.