### PR TITLE
WIP: Try using LIBRARY_PATH to catch built libs

### DIFF
--- a/tests/test_library_builders.sh
+++ b/tests/test_library_builders.sh
@@ -11,7 +11,7 @@ if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update; fi
 start_spinner
 
 suppress build_openssl
-suppress build_openblas
+suppress build_libpng
 suppress build_libwebp
 suppress build_szip
 suppress build_swig

--- a/travis_steps.sh
+++ b/travis_steps.sh
@@ -10,3 +10,7 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
 else
     source $MULTIBUILD_DIR/travis_linux_steps.sh
 fi
+
+# Promote BUILD_PREFIX on search path to find new zlib
+export CPPFLAGS="-L$BUILD_PREFIX/include $CPPFLAGS"
+export LDFLAGS="-L$BUILD_PREFIX/lib $LDFLAGS"

--- a/travis_steps.sh
+++ b/travis_steps.sh
@@ -11,6 +11,6 @@ else
     source $MULTIBUILD_DIR/travis_linux_steps.sh
 fi
 
-# Promote BUILD_PREFIX on search path to find new zlib
+# Promote BUILD_PREFIX on search path to any newly built libs
 export CPPFLAGS="-L$BUILD_PREFIX/include $CPPFLAGS"
-export LDFLAGS="-L$BUILD_PREFIX/lib $LDFLAGS"
+export LIBRARY_PATH="$BUILD_PREFIX/lib:$LIBRARY_PATH"


### PR DESCRIPTION
This is a version of https://github.com/matthew-brett/multibuild/pull/67 . That
pull request broke scipy builds because it sets LDFLAGS, which numpy uses in an
inconvenient way - see https://github.com/matthew-brett/multibuild/issues/76
for discussion.