### PR TITLE
Allow to specify a custom $CONFIG_PATH for config.sh

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -324,6 +324,9 @@ To use these scripts
         python -c 'import sys; import yourpackage; sys.exit(yourpackage.test())'
     }
 
+  Optionally you can specify a different location for ``config.sh`` file with
+  the ``$CONFIG_PATH`` environment variable.
+
 * Make sure your project is set up to build on travis-ci, and you should now
   be ready (to begin the long slow debugging process, probably).
   

--- a/docker_build_wrap.sh
+++ b/docker_build_wrap.sh
@@ -2,6 +2,7 @@
 # Depends on:
 #   BUILD_COMMANDS
 #   PYTHON_VERSION
+#   CONFIG_PATH (can be empty)
 #   BUILD_COMMIT (may be used by config.sh)
 #   UNICODE_WIDTH  (can be empty)
 #   BUILD_DEPENDS  (may be used by config.sh, can be empty)
@@ -12,6 +13,9 @@ UNICODE_WIDTH=${UNICODE_WIDTH:-32}
 
 # Location of wheels, default "wheelhouse"
 WHEEL_SDIR=${WHEEL_SDIR:-wheelhouse}
+
+# Location of `config.sh` file, default "./config.sh"
+CONFIG_PATH=${CONFIG_PATH:-config.sh}
 
 # Always pull in common and library builder utils
 MULTIBUILD_DIR=$(dirname "${BASH_SOURCE[0]}")
@@ -31,6 +35,6 @@ cd /io
 
 # Configuration for this package, possibly overriding `build_wheel` defined in
 # `common_utils.sh` via `manylinux_utils.sh`.
-source config.sh
+source "$CONFIG_PATH"
 
 $BUILD_COMMANDS

--- a/docker_test_wrap.sh
+++ b/docker_test_wrap.sh
@@ -13,6 +13,7 @@ cd /io
 # This can overwrite `install_run`' and `install_wheel` (called from
 # `install_run`). These are otherwise defined in common_utils.sh.
 # `config.sh` must define `run_tests` if using the default `install_run`.
-source config.sh
+CONFIG_PATH=${CONFIG_PATH:-config.sh}
+source "$CONFIG_PATH"
 
 install_run

--- a/travis_linux_steps.sh
+++ b/travis_linux_steps.sh
@@ -84,6 +84,7 @@ function build_multilinux {
         -e PYTHON_VERSION="$MB_PYTHON_VERSION" \
         -e UNICODE_WIDTH="$UNICODE_WIDTH" \
         -e BUILD_COMMIT="$BUILD_COMMIT" \
+        -e CONFIG_PATH="$CONFIG_PATH" \
         -e WHEEL_SDIR="$WHEEL_SDIR" \
         -e MANYLINUX_URL="$MANYLINUX_URL" \
         -e BUILD_DEPENDS="$BUILD_DEPENDS" \
@@ -115,6 +116,7 @@ function install_run {
         -e PYTHON_VERSION="$MB_PYTHON_VERSION" \
         -e MB_PYTHON_VERSION="$MB_PYTHON_VERSION" \
         -e UNICODE_WIDTH="$UNICODE_WIDTH" \
+        -e CONFIG_PATH="$CONFIG_PATH" \
         -e WHEEL_SDIR="$WHEEL_SDIR" \
         -e MANYLINUX_URL="$MANYLINUX_URL" \
         -e TEST_DEPENDS="$TEST_DEPENDS" \

--- a/travis_osx_steps.sh
+++ b/travis_osx_steps.sh
@@ -25,4 +25,5 @@ function before_install {
 
 # Local configuration may define custom pre-build, source patching.
 # It can also overwrite the functions above.
-source config.sh
+CONFIG_PATH=${CONFIG_PATH:-config.sh}
+source "$CONFIG_PATH"


### PR DESCRIPTION
I usually like to check-in `multibuild` as a git submodule inside my projects rather than creating a separate wheel builder git repostory.
And I also like to keep all the CI-related scripts and config files in a separate subfolder (e.g. `ci`), to avoid cluttering the root of the repository with files that are not normally needed and may confuse other developers.

This PR allows to set a `$CONFIG_PATH` environment variable with the location of the "config.sh" file.
The current behaviour doesn't change (it's an opt-in kind of feature).

Please let me know what you think, thanks. 