### PR TITLE
remove references to python 2.6 in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ The TravisCI scripts are designed to build *and test*:
 * 64-bit ``manylinux1_x86_64`` wheels, both narrow and wide unicode builds;
 * 32-bit ``manylinux1_i686`` wheels, both narrow and wide unicode builds.
 
-You can currently build and test against Pythons 2.6, 2.7, 3.3, 3.4, 3.5, 3.6.
+You can currently build and test against Pythons 2.7, 3.3, 3.4, 3.5, 3.6.
 
 The small innovation here is that you can test against 32-bit builds, and both
 wide and narrow unicode Python 2 builds, which was not easy on the default
@@ -195,13 +195,6 @@ To use these scripts
         # Exclude the default Python 3.5 build
         - python: 3.5
       include:
-        - os: linux
-          env:
-            - MB_PYTHON_VERSION=2.6
-        - os: linux
-          env:
-            - MB_PYTHON_VERSION=2.6
-            - PLAT=i686
         - os: linux
           env: MB_PYTHON_VERSION=2.7
         - os: linux


### PR DESCRIPTION
#111 dropped support