### PR TITLE
In xcode 6.4, `brew update' breaks `brew' due to old `ruby'.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ cache:
   directories:
    - $HOME/.ccache
 
+env:
+  global:
+    - HOMEBREW_NO_AUTO_UPDATE=1
+
 matrix:
   include:
     - os: linux

--- a/tests/test_library_builders.sh
+++ b/tests/test_library_builders.sh
@@ -4,10 +4,6 @@ export BUILD_PREFIX="${PWD}/builds"
 rm_mkdir $BUILD_PREFIX
 source library_builders.sh
 
-# set -e -x
-
-if [ -n "$IS_OSX" ]; then brew update; fi
-
 start_spinner
 
 suppress build_openssl


### PR DESCRIPTION
https://travis-ci.org/matthew-brett/multibuild/jobs/329985249#0-2249 :

    /usr/local/Homebrew/Library/Homebrew/brew.rb:12:in `<main>': Homebrew must be run under Ruby 2.3! You're running 2.0.0. (RuntimeError)

This may even be the reason for the build's failure.

https://docs.travis-ci.com/user/reference/osx/#Homebrew recommends to only run `brew update` if you must.