### PR TITLE
Strip binaries on non-OSX builds

### DIFF
--- a/configure_build.sh
+++ b/configure_build.sh
@@ -25,6 +25,13 @@ if [ -n "$IS_OSX" ]; then
 
     # Disable homebrew auto-update
     export HOMEBREW_NO_AUTO_UPDATE=1
+else
+    # Strip all binaries after compilation.
+    STRIP_FLAGS=${STRIP_FLAGS:-"-Wl,-strip-all"}
+
+    export CFLAGS="${CFLAGS:-$STRIP_FLAGS}"
+    export CXXFLAGS="${CXXFLAGS:-$STRIP_FLAGS}"
+    export FFLAGS="${FFLAGS:-$STRIP_FLAGS}"
 fi
 
 # Promote BUILD_PREFIX on search path to any newly built libs


### PR DESCRIPTION
Directly strip the binaries on compilation. Additionally I will have a look into integrating stripping into `auditwheel` but this change will prevent persisting the symbols in the first place. The savings are quite large here, e.g. for Pandas the sizes change 27M wheel and 104M unpacked on disk to a 11M wheel and 44M unpacked on disk. These saving are significantly visible in e.g. docker images that contain the unpacked binaries.

Verified with several packages as we had seen problems with this in the past:

 * `Pandas` https://travis-ci.org/xhochy/pandas-wheels/builds/337220847
 * `Cython` (2.6 builds fail as this version is no longer in the image) https://travis-ci.org/xhochy/cython-wheels/builds/337244795
 * `h5py` https://travis-ci.org/xhochy/h5py-wheels/builds/337245000
 * `matplotlib` https://travis-ci.org/xhochy/matplotlib-wheels/builds/337246063
 * `numpy` https://travis-ci.org/xhochy/numpy-wheels/builds/337247346
 * `numexpr` https://travis-ci.org/xhochy/numexpr-wheels/builds/337248103
 * `pytables` https://travis-ci.org/xhochy/pytables-wheels/builds/337248798
 * `scipy` https://travis-ci.org/xhochy/scipy-wheels/builds/337663919
   * with special fix: https://github.com/xhochy/scipy-wheels/commit/393141bde28311000fea0cb60a17ea04c2d59113#diff-56755ef7919deca2e30854b110f67bdeR13