### PR TITLE
Add function to build cfitsio

### DIFF
--- a/library_builders.sh
+++ b/library_builders.sh
@@ -384,6 +384,7 @@ function build_flex {
 }
 
 function build_cfitsio {
+    if [ -e cfitsio-stamp ]; then return; fi
     if [ -n "$IS_OSX" ]; then
         brew install cfitsio
     else
@@ -394,4 +395,5 @@ function build_cfitsio {
             && ./configure --prefix=$BUILD_PREFIX \
             && make shared && make install)
     fi
+    touch cfitsio-stamp
 }

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -39,6 +39,7 @@ LIBTOOL_VERSION=${LIBTOOL_VERSION:-2.4.6}
 RAGEL_VERSION=${RAGEL_VERSION:-6.10}
 FLEX_VERSION=${FLEX_VERSION:-2.6.4}
 BISON_VERSION=${BISON_VERSION:-3.0.4}
+CFITSIO_VERSION=${CFITSIO_VERSION:-3370}
 OPENSSL_ROOT=openssl-1.0.2l
 # Hash from https://www.openssl.org/source/openssl-1.0.2?.tar.gz.sha256
 OPENSSL_HASH=ce07195b659e75f4e1db43552860070061f156a98bb37b672b101ba6e3ddf30c
@@ -380,4 +381,17 @@ function build_flex {
     # the flex repository's git tags have a 'v' prefix
     build_simple flex $FLEX_VERSION \
         https://github.com/westes/flex/releases/download/v$FLEX_VERSION
+}
+
+function build_cfitsio {
+    if [ -n "$IS_OSX" ]; then
+        brew install cfitsio
+    else
+        # cannot use build_simple because cfitsio has no dash between name and version
+        local cfitsio_name_ver=cfitsio${CFITSIO_VERSION}
+        fetch_unpack https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/${cfitsio_name_ver}.tar.gz
+        (cd cfitsio \
+            && ./configure --prefix=$BUILD_PREFIX \
+            && make shared && make install)
+    fi
 }


### PR DESCRIPTION
Not sure which default version is the best. I chose 3.370 because it's the one in debian oldstable, but I don't know if it necessary to use an old version for binary compatibility ? 