### PR TITLE
Update manylinux URL

### DIFF
--- a/travis_linux_steps.sh
+++ b/travis_linux_steps.sh
@@ -11,7 +11,7 @@
 #  install_run
 set -e
 
-MANYLINUX_URL=${MANYLINUX_URL:-https://nipy.bic.berkeley.edu/manylinux}
+MANYLINUX_URL=${MANYLINUX_URL:-https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com}
 
 # Get our own location on this filesystem
 MULTIBUILD_DIR=$(dirname "${BASH_SOURCE[0]}")


### PR DESCRIPTION
Nipy server's certificate is out of date, switch to using Rackspace
container instead.

I've gone through the files available at http://nipy.bic.berkeley.edu/manylinux
- and I think the Rackspace container has all the ones we care about.  I
suggest we merge here and wait for complaints.