### PR TITLE
Removed micro Python version specification in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,16 +26,16 @@ matrix:
     - os: osx
       osx_image: xcode6.4
       env:
-        - PYTHON_VERSION=2.7.11
+        - PYTHON_VERSION=2.7
         - VENV=venv
     - os: osx
       env:
-        - PYTHON_VERSION=2.7.11
+        - PYTHON_VERSION=2.7
         - TEST_BUILDS=1
     - os: osx
       language: objective-c
       env:
-        - PYTHON_VERSION=2.7.11
+        - PYTHON_VERSION=2.7
         - VENV=venv
     - os: osx
       osx_image: xcode6.4
@@ -43,25 +43,25 @@ matrix:
         - PYTHON_VERSION=3.3
     - os: osx
       env:
-        - PYTHON_VERSION=3.4.4
+        - PYTHON_VERSION=3.4
     - os: osx
       env:
-        - PYTHON_VERSION=3.4.4
+        - PYTHON_VERSION=3.4
         - VENV=venv
     - os: osx
       env:
-        - PYTHON_VERSION=3.5.3
+        - PYTHON_VERSION=3.5
     - os: osx
       env:
-        - PYTHON_VERSION=3.5.3
+        - PYTHON_VERSION=3.5
         - VENV=venv
     - os: osx
       env:
-        - PYTHON_VERSION=3.6.1
+        - PYTHON_VERSION=3.6
         - VENV=venv
     - os: osx
       env:
-        - PYTHON_VERSION=3.6.1
+        - PYTHON_VERSION=3.6
         - VENV=venv
         - USE_CCACHE=1
     - os: osx


### PR DESCRIPTION
Perhaps there is a reason for specifying the micro Python versions, but something like 2.7.11 is no longer the latest version. It could be changed to 2.7.15, or, as in this PR, supplying the version [as 2.7 instead allows it to be kept up-to-date automatically](https://docs.travis-ci.com/user/languages/python/#Specifying-Python-versions).