### PR TITLE
Allow building latest tag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -167,7 +167,7 @@ To use these scripts
         global:
             - REPO_DIR=your-project
             # Commit from your-project that you want to build
-            - BUILD_COMMIT=v0.1.0
+            - BUILD_COMMIT=v0.1.0  # or `latest-tag`
             # pip dependencies to _build_ your project
             - BUILD_DEPENDS="Cython numpy"
             # pip dependencies to _test_ your project.  Include any dependencies

--- a/common_utils.sh
+++ b/common_utils.sh
@@ -161,6 +161,11 @@ function clean_code {
     local build_commit=${2:-$BUILD_COMMIT}
     [ -z "$repo_dir" ] && echo "repo_dir not defined" && exit 1
     [ -z "$build_commit" ] && echo "build_commit not defined" && exit 1
+
+    if [[ "$build_commit" == "latest-tag" ]]; then
+        build_commit=$(latest_tag)
+    fi
+
     # The package $repo_dir may be a submodule. git submodules do not
     # have a .git directory. If $repo_dir is copied around, tools like
     # Versioneer which require that it be a git repository are unable

--- a/common_utils.sh
+++ b/common_utils.sh
@@ -316,6 +316,15 @@ function fill_submodule {
     (cd "$repo_dir" && git remote set-url origin $origin_url)
 }
 
+function latest_tag {
+    rev=$(git rev-list --tags --max-count=1)
+    if [[ -z $rev ]]; then
+        echo "master"
+    else
+        echo $(git describe $rev)
+    fi
+}
+
 PYPY_URL=https://bitbucket.org/pypy/pypy/downloads
 
 # As of 2018-01-14, the latest verions of PyPy.


### PR DESCRIPTION
This allows specifying `latest-tag` as the build branch. 