### PR TITLE
Changed TEST_DEPENDS pip install to install one package at a time

### DIFF
--- a/common_utils.sh
+++ b/common_utils.sh
@@ -323,7 +323,9 @@ function install_wheel {
     #     MANYLINUX_URL (optional, default "") (via pip_opts function)
     local wheelhouse=$(abspath ${WHEEL_SDIR:-wheelhouse})
     if [ -n "$TEST_DEPENDS" ]; then
-        pip install $(pip_opts) $@ $TEST_DEPENDS
+        for TEST_DEPENDENCY in $TEST_DEPENDS; do
+            pip install $(pip_opts) $@ $TEST_DEPENDENCY
+        done
     fi
     # Install compatible wheel
     pip install $(pip_opts) $@ \

--- a/common_utils.sh
+++ b/common_utils.sh
@@ -323,9 +323,9 @@ function install_wheel {
     #     MANYLINUX_URL (optional, default "") (via pip_opts function)
     local wheelhouse=$(abspath ${WHEEL_SDIR:-wheelhouse})
     if [ -n "$TEST_DEPENDS" ]; then
-        for TEST_DEPENDENCY in $TEST_DEPENDS; do
+        while read TEST_DEPENDENCY; do
             pip install $(pip_opts) $@ $TEST_DEPENDENCY
-        done
+        done <<< "$TEST_DEPENDS"
     fi
     # Install compatible wheel
     pip install $(pip_opts) $@ \


### PR DESCRIPTION
In https://github.com/python-pillow/Pillow-wheels, `TEST_DEPENDS="pytest pytest-cov numpy scipy"`. scipy depends on numpy, and so if you try to install scipy and numpy at the same time, you receive an error that numpy is not present - https://travis-ci.org/python-pillow/pillow-wheels/jobs/397965939#L4956. This is not normally the case - it would seem to be happening here because wheels do not yet exist for Python 3.7.

So instead, for this scenario, I suggest installing TEST_DEPENDS packages one at a time.

Note that this doesn't solve that pillow-wheels build completely, but it's a step in the right direction, and worthwhile as a change in it's own right.