### PR TITLE
Add script to install new Python on Appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -53,7 +53,6 @@ install:
     # this repo includes a simple package to test appveyor
     - git clone git://github.com/ogrisel/python-appveyor-demo.git
 
-
 build_script:
     # Install build requirements
     - conda install --yes %BUILD_DEPENDS%
@@ -75,3 +74,9 @@ test_script:
     # run tests from install wheel
     - cd ..
     - python -m pyappveyordemo.tests.test_extension
+
+    # Smoke test of install_python script
+    - set PYTHON=C:\Python37
+    - ps: .\install_python.ps1
+    - set PYTHON=C:\Python37-x64
+    - ps: .\install_python.ps1

--- a/install_python.ps1
+++ b/install_python.ps1
@@ -1,0 +1,31 @@
+# Install specified Python version.
+# Install only if:
+#    Our current matrix entry uses this Python version AND
+#    Python version is not already available.
+
+$py_exe = "${env:PYTHON}\Python.exe"
+if ( [System.IO.File]::Exists($py_exe) ) {
+    exit 0
+}
+$req_nodot = $env:PYTHON -replace '\D+Python(\d+)(?:-x64)?','$1'
+$req_ver = $req_nodot -replace '(\d)(\d+)','$1.$2.0'
+
+if ($env:PYTHON -eq "C:\Python${req_nodot}-x64") {
+    $exe_suffix="-amd64"
+} elseif ($env:PYTHON -eq "C:\Python${req_nodot}") {
+    $exe_suffix=""
+} else {
+    exit 0
+}
+
+$py_url = "https://www.python.org/ftp/python"
+Write-Host "Installing Python ${req_ver}$exe_suffix..." -ForegroundColor Cyan
+$exePath = "$env:TEMP\python-${req_ver}${exe_suffix}.exe"
+$downloadFile = "$py_url/${req_ver}/python-${req_ver}${exe_suffix}.exe"
+Write-Host "Downloading $downloadFile..."
+(New-Object Net.WebClient).DownloadFile($downloadFile, $exePath)
+Write-Host "Installing..."
+cmd /c start /wait $exePath /quiet TargetDir="$env:PYTHON" Shortcuts=0 Include_launcher=0 InstallLauncherAllUsers=0
+Write-Host "Python ${req_ver} installed to $env:PYTHON"
+
+echo "$(& $py_exe --version 2> $null)"


### PR DESCRIPTION
Powershell script to download and install a new version of Python, if not
present on the Appveyor image.

This should make it easier to get out wheels after a Python release.