### PR TITLE
MRG: fixes for bzip website; noisy zip unpacking

### DIFF
--- a/common_utils.sh
+++ b/common_utils.sh
@@ -139,7 +139,7 @@ function untar {
         tar) tar -xf $in_fname ;;
         gz|tgz) tar -zxf $in_fname ;;
         bz2) tar -jxf $in_fname ;;
-        zip) unzip $in_fname ;;
+        zip) unzip -qq $in_fname ;;
         xz) unxz -c $in_fname | tar -xf ;;
         *) echo Did not recognize extension $extension; exit 1 ;;
     esac

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -14,6 +14,8 @@ OPENBLAS_VERSION="${OPENBLAS_VERSION:-0.2.18}"
 ZLIB_VERSION="${ZLIB_VERSION:-1.2.10}"
 LIBPNG_VERSION="${LIBPNG_VERSION:-1.6.21}"
 BZIP2_VERSION="${BZIP2_VERSION:-1.0.6}"
+# BZIP website went down as of August 8 2018
+BZIP_URL=https://web.archive.org/web/20180624184806/http://bzip.org
 FREETYPE_VERSION="${FREETYPE_VERSION:-2.6.3}"
 TIFF_VERSION="${TIFF_VERSION:-4.0.6}"
 JPEG_VERSION="${JPEG_VERSION:-9b}"
@@ -137,7 +139,7 @@ function build_libpng {
 function build_bzip2 {
     if [ -n "$IS_OSX" ]; then return; fi  # OSX has bzip2 libs already
     if [ -e bzip2-stamp ]; then return; fi
-    fetch_unpack http://bzip.org/${BZIP2_VERSION}/bzip2-${BZIP2_VERSION}.tar.gz
+    fetch_unpack $BZIP_URL/${BZIP2_VERSION}/bzip2-${BZIP2_VERSION}.tar.gz
     (cd bzip2-${BZIP2_VERSION} \
         && make -f Makefile-libbz2_so \
         && make install PREFIX=$BUILD_PREFIX)


### PR DESCRIPTION
The bzip.org website seems to have gone down and has a sitter there.

Also, make unzipping quiet to get the output directory back.