### PR TITLE
Pass MB_PYTHON_VERSION to docker run in build_multilinux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -169,4 +169,5 @@ matrix:
 
 script:
   - export ENV_VARS_PATH="tests/env_vars.sh"
+  - export CONFIG_PATH="tests/config.sh"
   - source tests/test_multibuild.sh

--- a/tests/config.sh
+++ b/tests/config.sh
@@ -1,0 +1,12 @@
+source tests/utils.sh
+
+function pre_build {
+    [ -n "$MB_PYTHON_VERSION" ] || ingest "MB_PYTHON_VERSION not defined"
+
+    if [ -z "$IS_OSX" ] && [ "$MB_PYTHON_VERSION" != "$PYTHON_VERSION" ]; then
+        ingest "\$MB_PYTHON_VERSION must be equal to \$PYTHON_VERSION"
+    fi
+
+    # Exit 1 if any test errors
+    barf
+}

--- a/tests/test_multibuild.sh
+++ b/tests/test_multibuild.sh
@@ -1,5 +1,6 @@
 # Test multibuild utilities
 export PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+export MB_PYTHON_VERSION=$PYTHON_VERSION
 set -x
 source common_utils.sh
 source tests/utils.sh

--- a/tests/test_multibuild.sh
+++ b/tests/test_multibuild.sh
@@ -23,7 +23,6 @@ if [ -n "$TEST_BUILDS" ]; then
     elif [ ! -x "$(command -v docker)" ]; then
         echo "Skipping build tests; no docker available"
     else
-        touch config.sh
         source travis_linux_steps.sh
         build_multilinux $PLAT "source tests/test_library_builders.sh"
     fi

--- a/tests/test_multibuild.sh
+++ b/tests/test_multibuild.sh
@@ -20,11 +20,14 @@ fi
 if [ -n "$TEST_BUILDS" ]; then
     if [ -n "$IS_OSX" ]; then
         source tests/test_library_builders.sh
+        source travis_osx_steps.sh
+        pre_build
     elif [ ! -x "$(command -v docker)" ]; then
         echo "Skipping build tests; no docker available"
     else
         source travis_linux_steps.sh
         build_multilinux $PLAT "source tests/test_library_builders.sh"
+        build_multilinux $PLAT "pre_build"
     fi
 fi
 

--- a/travis_linux_steps.sh
+++ b/travis_linux_steps.sh
@@ -84,6 +84,7 @@ function build_multilinux {
     docker run --rm \
         -e BUILD_COMMANDS="$build_cmds" \
         -e PYTHON_VERSION="$MB_PYTHON_VERSION" \
+        -e MB_PYTHON_VERSION="$MB_PYTHON_VERSION" \
         -e UNICODE_WIDTH="$UNICODE_WIDTH" \
         -e BUILD_COMMIT="$BUILD_COMMIT" \
         -e CONFIG_PATH="$CONFIG_PATH" \


### PR DESCRIPTION
It is useful sometimes (e.g. in config.sh's pre_build') to do stuff based on the current python version.
The problem is that when running inside the docker container the variable MB_PYTHON_VERSION is passed on only as PYTHON_VERSION without the MB_ prefix, but in the macOS environment the latter is not present. Thus, one needs to check both PYTHON_VERSION and MB_PYTHON_VERSION.

Better to pass both to the docker container, so one can just check the value of MB_PYTHON_VERSION on both mac and linux.

Note that the same hack is used in the 'install_run' function, where both PYTHON_VERSION and MB_PYTHON_VERSION are passed through to docker run.