### PR TITLE
Drop support for EOL Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,10 +50,6 @@ matrix:
         - PYTHON_VERSION=2.7
         - VENV=venv
     - os: osx
-      osx_image: xcode6.4
-      env:
-        - PYTHON_VERSION=3.3
-    - os: osx
       env:
         - PYTHON_VERSION=3.4
     - os: osx

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ The Travis CI scripts are designed to build *and test*:
 * 64-bit ``manylinux1_x86_64`` wheels, both narrow and wide Unicode builds;
 * 32-bit ``manylinux1_i686`` wheels, both narrow and wide Unicode builds.
 
-You can currently build and test against Pythons 2.7, 3.3, 3.4, 3.5, 3.6, 3.7.
+You can currently build and test against Pythons 2.7, 3.4, 3.5, 3.6, 3.7.
 
 The small innovation here is that you can test against 32-bit builds, and both
 wide and narrow Unicode Python 2 builds, which was not easy on the default
@@ -213,13 +213,6 @@ To use these scripts
             - MB_PYTHON_VERSION=2.7
             - PLAT=i686
             - UNICODE_WIDTH=16
-        - os: linux
-          env:
-            - MB_PYTHON_VERSION=3.3
-        - os: linux
-          env:
-            - MB_PYTHON_VERSION=3.3
-            - PLAT=i686
         - os: linux
           env:
             - MB_PYTHON_VERSION=3.4

--- a/manylinux_utils.sh
+++ b/manylinux_utils.sh
@@ -23,8 +23,8 @@ function cpython_path {
     local u_suff=u
     # Back-compatibility
     if [ "$u_width" == "u" ]; then u_width=32; fi
-    # For Python >= 3.3, "u" suffix not meaningful
-    if [ $(lex_ver $py_ver) -ge $(lex_ver 3.3) ] ||
+    # For Python >= 3.4, "u" suffix not meaningful
+    if [ $(lex_ver $py_ver) -ge $(lex_ver 3.4) ] ||
         [ "$u_width" == "16" ]; then
         u_suff=""
     elif [ "$u_width" != "32" ]; then

--- a/osx_utils.sh
+++ b/osx_utils.sh
@@ -16,9 +16,6 @@ WORKING_SDIR=working
 # available.
 # See: https://www.python.org/downloads/mac-osx/
 LATEST_2p7=2.7.15
-LATEST_2p6=2.6.6
-LATEST_3p2=3.2.5
-LATEST_3p3=3.3.5
 LATEST_3p4=3.4.4
 LATEST_3p5=3.5.4
 LATEST_3p6=3.6.7
@@ -79,8 +76,6 @@ function fill_pyver {
         echo $ver
     elif [ $ver == 2 ] || [ $ver == "2.7" ]; then
         echo $LATEST_2p7
-    elif [ $ver == "2.6" ]; then
-        echo $LATEST_2p6
     elif [ $ver == 3 ] || [ $ver == "3.7" ]; then
         echo $LATEST_3p7
     elif [ $ver == "3.6" ]; then
@@ -89,10 +84,6 @@ function fill_pyver {
         echo $LATEST_3p5
     elif [ $ver == "3.4" ]; then
         echo $LATEST_3p4
-    elif [ $ver == "3.3" ]; then
-        echo $LATEST_3p3
-    elif [ $ver == "3.2" ]; then
-        echo $LATEST_3p2
     else
         echo "Can't fill version $ver" 1>&2
         exit 1

--- a/osx_utils.sh
+++ b/osx_utils.sh
@@ -198,12 +198,7 @@ function install_pip {
     mkdir -p $DOWNLOADS_SDIR
     local py_mm=`get_py_mm`
     local get_pip_path=$DOWNLOADS_SDIR/get-pip.py
-    # pip 18.0 dropped support for Python 3.3
-    if [ "$py_mm" == "3.3" ]; then
-        curl https://bootstrap.pypa.io/3.3/get-pip.py > $get_pip_path
-    else
-	    curl $GET_PIP_URL > $get_pip_path
-    fi
+    curl $GET_PIP_URL > $get_pip_path
     # Python 2.6 will fail SSL check
     if [ "$py_mm" == "2.6" ]; then
         local pip_args="--trusted-host=pypi.org"

--- a/tests/test_fill_pyver.sh
+++ b/tests/test_fill_pyver.sh
@@ -2,8 +2,6 @@
 [ "$(fill_pyver 2)" == $LATEST_2p7 ] || ingest
 [ "$(fill_pyver 2.7)" == $LATEST_2p7 ] || ingest
 [ "$(fill_pyver 2.7.8)" == "2.7.8" ] || ingest
-[ "$(fill_pyver 2.6)" == $LATEST_2p6 ] || ingest
-[ "$(fill_pyver 2.6.2)" == "2.6.2" ] || ingest
 [ "$(fill_pyver 3)" == $LATEST_3p7 ] || ingest
 [ "$(fill_pyver 3.7.0)" == "3.7.0" ] || ingest
 [ "$(fill_pyver 3.7)" == $LATEST_3p7 ] || ingest
@@ -12,5 +10,3 @@
 [ "$(fill_pyver 3.5)" == $LATEST_3p5 ] || ingest
 [ "$(fill_pyver 3.5.0)" == "3.5.0" ] || ingest
 [ "$(fill_pyver 3.4)" == $LATEST_3p4 ] || ingest
-[ "$(fill_pyver 3.3)" == $LATEST_3p3 ] || ingest
-[ "$(fill_pyver 3.2)" == $LATEST_3p2 ] || ingest

--- a/tests/test_manylinux_utils.sh
+++ b/tests/test_manylinux_utils.sh
@@ -1,15 +1,9 @@
 # Tests for manylinux utils
 
 # cpython path calculator
-[ "$(cpython_path 2.6)" == "/opt/python/cp26-cp26mu" ] || ingest "cp 2.6"
-[ "$(cpython_path 2.6 32)" == "/opt/python/cp26-cp26mu" ] || ingest "cp 2.6 32"
-[ "$(cpython_path 2.6 16)" == "/opt/python/cp26-cp26m" ] || ingest "cp 2.6 16"
 [ "$(cpython_path 2.7)" == "/opt/python/cp27-cp27mu" ] || ingest "cp 2.7"
 [ "$(cpython_path 2.7 32)" == "/opt/python/cp27-cp27mu" ] || ingest "cp 2.7 32"
 [ "$(cpython_path 2.7 16)" == "/opt/python/cp27-cp27m" ] || ingest "cp 2.7 16"
-[ "$(cpython_path 3.3)" == "/opt/python/cp33-cp33m" ] || ingest "cp 3.3"
-[ "$(cpython_path 3.3 32)" == "/opt/python/cp33-cp33m" ] || ingest "cp 3.3 32"
-[ "$(cpython_path 3.3 16)" == "/opt/python/cp33-cp33m" ] || ingest "cp 3.3 16"
 [ "$(cpython_path 3.4)" == "/opt/python/cp34-cp34m" ] || ingest "cp 3.4"
 [ "$(cpython_path 3.4 32)" == "/opt/python/cp34-cp34m" ] || ingest "cp 3.4 32"
 [ "$(cpython_path 3.4 16)" == "/opt/python/cp34-cp34m" ] || ingest "cp 3.4 16"

--- a/tests/test_osx_utils.sh
+++ b/tests/test_osx_utils.sh
@@ -5,14 +5,11 @@
 [ "$(pyinst_ext_for_version 2.7.9)" == pkg ] || ingest
 [ "$(pyinst_ext_for_version 2.7)" == pkg ] || ingest
 [ "$(pyinst_ext_for_version 2)" == pkg ] || ingest
-[ "$(pyinst_ext_for_version 3.3.5)" == dmg ] || ingest
 [ "$(pyinst_ext_for_version 3.4.1)" == dmg ] || ingest
 [ "$(pyinst_ext_for_version 3.4.2)" == pkg ] || ingest
 [ "$(pyinst_ext_for_version 3.5.0)" == pkg ] || ingest
-[ "$(pyinst_ext_for_version 3.3)" == dmg ] || ingest
 [ "$(pyinst_ext_for_version 3.4)" == pkg ] || ingest
 [ "$(pyinst_ext_for_version 3)" == pkg ] || ingest
-[ "$(pyinst_fname_for_version 2.6.6)" == "python-2.6.6-macosx10.3.dmg" ] || ingest
 [ "$(pyinst_fname_for_version 2.7.8)" == "python-2.7.8-macosx10.6.dmg" ] || ingest
 [ "$(pyinst_fname_for_version 2.7.9)" == "python-2.7.9-macosx10.6.pkg" ] || ingest
 [ "$(pyinst_fname_for_version 3.4.1)" == "python-3.4.1-macosx10.6.dmg" ] || ingest


### PR DESCRIPTION
Python 3.3 has been EOL since 2017-09-29, and has already been dropped by manylinux: 

https://github.com/pypa/manylinux/pull/188