### PR TITLE
Pin wheel to 0.31.1

### DIFF
--- a/travis_linux_steps.sh
+++ b/travis_linux_steps.sh
@@ -24,7 +24,7 @@ function before_install {
     virtualenv --python=python venv
     source venv/bin/activate
     python --version # just to check
-    pip install --upgrade pip wheel
+    pip install --upgrade pip wheel==0.31.1
 }
 
 function build_wheel {

--- a/travis_osx_steps.sh
+++ b/travis_osx_steps.sh
@@ -24,7 +24,7 @@ function before_install {
     export CXX=clang++
     get_macpython_environment $MB_PYTHON_VERSION venv
     source venv/bin/activate
-    pip install --upgrade pip wheel
+    pip install --upgrade pip wheel==0.31.1
 }
 
 # build_wheel function defined in common_utils (via osx_utils)


### PR DESCRIPTION
0.32 broke the universe. See the following for more info:

https://github.com/pypa/auditwheel/issues/102
https://github.com/pypa/wheel/issues/255
https://github.com/python-pillow/pillow-wheels/pull/102

@matthew-brett by my reading these are the bits that need to be updated for skimage wheels to work again?