### PR TITLE
 Wrapper to catch yum package not found

### DIFF
--- a/common_utils.sh
+++ b/common_utils.sh
@@ -98,7 +98,7 @@ function gh-clone {
 function set_opts {
     # Set options from input options string (in $- format).
     local opts=$1
-    local chars="exhimBH"
+    local chars="exhmBH"
     for (( i=0; i<${#chars}; i++ )); do
         char=${chars:$i:1}
         [ -n "${opts//[^${char}]/}" ] && set -$char || set +$char

--- a/common_utils.sh
+++ b/common_utils.sh
@@ -148,7 +148,7 @@ function untar {
 
 function install_rsync {
     if [ -z "$IS_OSX" ]; then
-        [[ $(type -P rsync) ]] || yum install -y rsync
+        [[ $(type -P rsync) ]] || yum_install rsync
     fi
 }
 

--- a/common_utils.sh
+++ b/common_utils.sh
@@ -113,13 +113,14 @@ function suppress {
     # Set -e stuff agonized over in
     # https://unix.stackexchange.com/questions/296526/set-e-in-a-subshell
     local tmp=$(mktemp tmp.XXXXXXXXX) || return
-    local opts=$-
+    local ERREXIT_SET OUT
     echo "Running $@"
+    if [[ $- = *e* ]]; then ERREXIT_SET=true; fi
     set +e
-    ( set_opts $opts ; $@  > "$tmp" 2>&1 ) ; ret=$?
+    ( if [[ -n $ERREXIT_SET ]]; then set -e; fi; "$@"  > "$tmp" 2>&1 ) ; ret=$?
     [ "$ret" -eq 0 ] || cat "$tmp"
     rm -f "$tmp"
-    set_opts $opts
+    if [[ -n $ERREXIT_SET ]]; then set -e; fi
     return "$ret"
 }
 

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -111,7 +111,7 @@ function build_zlib {
     # Gives an old but safe version
     if [ -n "$IS_OSX" ]; then return; fi  # OSX has zlib already
     if [ -e zlib-stamp ]; then return; fi
-    yum install -y zlib-devel
+    yum_install zlib-devel
     touch zlib-stamp
 }
 
@@ -158,7 +158,7 @@ function get_cmake {
     if [ -n "$IS_OSX" ]; then
         brew install cmake > /dev/null
     else
-        yum install -y cmake28 > /dev/null
+        yum_install cmake28 > /dev/null
         cmake=cmake28
     fi
     echo $cmake
@@ -360,7 +360,7 @@ function build_suitesparse {
     if [ -n "$IS_OSX" ]; then
         brew install suite-sparse > /dev/null
     else
-        yum install -y suitesparse-devel > /dev/null
+        yum_install suitesparse-devel > /dev/null
     fi
     touch suitesparse-stamp
 }

--- a/manylinux_utils.sh
+++ b/manylinux_utils.sh
@@ -56,7 +56,7 @@ function activate_ccache {
     ln -s /parent-home/.ccache $HOME/.ccache
 
     # Now install ccache
-    suppress yum install -y ccache
+    suppress yum_install ccache
 
     # Create fake compilers and prepend them to the PATH
     # Note that yum is supposed to create these for us,
@@ -71,4 +71,9 @@ function activate_ccache {
 
     # Prove to the developer that ccache is activated
     echo "Using C compiler: $(which gcc)"
+}
+function yum_install {
+    # CentOS 5 yum doesn't fail in some cases, e.g. if package is not found
+    # https://serverfault.com/questions/694942/yum-should-error-when-a-package-is-not-available
+    yum install -y "$1" && rpm -q "$1"
 }

--- a/tests/test_common_utils.sh
+++ b/tests/test_common_utils.sh
@@ -69,6 +69,8 @@ ORIG_OPTS=$-
 set +ex
 [ "$(suppress bad_cmd)" == "$(printf "Running bad_cmd\nbad")" ] \
     || ingest "suppress bad_cmd"
+suppress bash -c '! false' &>/dev/null \
+    || ingest "suppress cmd with space"
 [ "$(suppress good_cmd)" == "Running good_cmd" ] \
     || ingest "suppress good_cmd"
 [ "$(suppress bad_mid_cmd)" == "Running bad_mid_cmd" ] \

--- a/tests/test_common_utils.sh
+++ b/tests/test_common_utils.sh
@@ -64,7 +64,7 @@ function good_cmd {
 }
 
 # Store state of options including -e, -x
-# https://stackoverflow.com/questions/14564746/in-bash-how-to-get-the-current-status-of-set-x?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa
+# https://stackoverflow.com/questions/14564746/in-bash-how-to-get-the-current-status-of-set-x
 ORIG_OPTS=$-
 set +ex
 [ "$(suppress bad_cmd)" == "$(printf "Running bad_cmd\nbad")" ] \

--- a/tests/test_manylinux_utils.sh
+++ b/tests/test_manylinux_utils.sh
@@ -1,4 +1,4 @@
-# Tests for manylinux utils
+# Tests for manylinux utils that can run outside docker
 
 # CPython path calculator
 [ "$(cpython_path 2.7)" == "/opt/python/cp27-cp27mu" ] || ingest "cp 2.7"

--- a/tests/test_manylinux_utils_docker.sh
+++ b/tests/test_manylinux_utils_docker.sh
@@ -1,0 +1,10 @@
+# Tests for manylinux utils that must run inside docker
+
+source manylinux_utils.sh
+source tests/utils.sh
+
+suppress yum_install rsync && suppress yum erase -y rsync \
+    || ingest "yum_install valid"
+suppress bash -c '! yum_install nonexistent' || ingest "yum_install nonexistent"
+
+barf

--- a/tests/test_multibuild.sh
+++ b/tests/test_multibuild.sh
@@ -25,7 +25,10 @@ if [ -n "$TEST_BUILDS" ]; then
     else
         touch config.sh
         source travis_linux_steps.sh
-        build_multilinux $PLAT "source tests/test_library_builders.sh"
+        build_multilinux $PLAT "
+            source tests/test_manylinux_utils_docker.sh
+            source tests/test_library_builders.sh
+        "
     fi
 fi
 


### PR DESCRIPTION
[I've hit a problem installing `ccache`](https://travis-ci.org/native-api/opencv-python/jobs/457726222#L647) that `suppress` didn't catch (the log is from a patched `activate_ccache` without `suppress` -- otherwise, I don't see anything):

```
+ yum install -y ccache
Not using downloaded repomd.xml because it is older than what we have:
  Current   : Thu Mar 30 15:57:07 2017
  Downloaded: Thu Mar 30 15:57:06 2017
Setting up Install Process
No package ccache available.
Nothing to do
```

According to https://serverfault.com/questions/694942/yum-should-error-when-a-package-is-not-available, RHEL 5 `yum install` indeed does not report with an exit code if a package is not found.

Other commits are changes needed to run tests for the added wrapper; the `set -i` I bumped into when running tests locally.

The `ERREXIT_SET` change I took from Travis work script that it generates for jobs. It produces much less trace output than `set_opts`.