### PR TITLE
Removed Xcode 6.4 builds from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,11 +36,6 @@ matrix:
       sudo: required
     # OSX builds
     - os: osx
-      osx_image: xcode6.4
-      env:
-        - PYTHON_VERSION=2.7
-        - VENV=venv
-    - os: osx
       env:
         - PYTHON_VERSION=2.7
         - TEST_BUILDS=1
@@ -156,10 +151,6 @@ matrix:
         - PYTHON_VERSION=3.5
     - os: osx
       osx_image: xcode7.3
-      env:
-        - PYTHON_VERSION=3.5
-    - os: osx
-      osx_image: xcode6.4
       env:
         - PYTHON_VERSION=3.5
 


### PR DESCRIPTION
As seen at https://travis-ci.org/matthew-brett/multibuild/jobs/454975750

> Running builds with Xcode 6.4 in Travis CI is deprecated and will be removed in January 2019. If Xcode 6.4 is critical to your builds, please contact our support team at support@travis-ci.com to discuss options.