### PR TITLE
Add $PLAT env

### DIFF
--- a/manylinux_utils.sh
+++ b/manylinux_utils.sh
@@ -42,7 +42,7 @@ function repair_wheelhouse {
         if [[ $whl == *none-any.whl ]]; then  # Pure Python wheel
             if [ "$in_dir" != "$out_dir" ]; then cp $whl $out_dir; fi
         else
-            auditwheel repair $whl -w $out_dir/
+            auditwheel repair --plat ${PLAT:-manylinux1_$(uname -m)} $whl -w $out_dir/
             # Remove unfixed if writing into same directory
             if [ "$in_dir" == "$out_dir" ]; then rm $whl; fi
         fi


### PR DESCRIPTION
passed to auditwheel --plat

needed for building manylinux2010 wheels

e.g. PLAT=manylinux2010_x86_64

default should be unchanged