### PR TITLE
Remove temporary directory if empty

### DIFF
--- a/common_utils.sh
+++ b/common_utils.sh
@@ -337,6 +337,7 @@ function install_run {
     install_wheel
     mkdir tmp_for_test
     (cd tmp_for_test && run_tests)
+    rmdir tmp_for_test 2>/dev/null
 }
 
 function fill_submodule {


### PR DESCRIPTION
See what you think of this - clean up the temporary directory 'tmp_for_test' at the end of `install_run` if no files are left inside.