### PR TITLE
Remove "remove OCLint" workaround

### DIFF
--- a/library_builders.sh
+++ b/library_builders.sh
@@ -92,8 +92,6 @@ function build_github {
 function build_openblas {
     if [ -e openblas-stamp ]; then return; fi
     if [ -n "$IS_OSX" ]; then
-        # https://github.com/travis-ci/travis-ci/issues/8826
-        brew cask uninstall oclint || echo "no oclint"
         brew install openblas
         brew link --force openblas
     else

--- a/travis_osx_steps.sh
+++ b/travis_osx_steps.sh
@@ -18,8 +18,6 @@ source $MULTIBUILD_DIR/library_builders.sh
 # config.sh can override any function defined here.
 
 function before_install {
-    # Uninstall oclint. See Travis-CI gh-8826
-    brew cask uninstall oclint || true    
     export CC=clang
     export CXX=clang++
     get_macpython_environment $MB_PYTHON_VERSION venv


### PR DESCRIPTION
Since https://github.com/travis-ci/travis-build/commit/52c6b6cc1d537e52c8ae6f0906944d6fcaa3d173, it's no longer needed

and may trigger stuff like [unnecessary `git clone`s](https://travis-ci.org/skvark/opencv-python/jobs/569294041#L2310).