### PR TITLE
Rename 'gh-clone' to fix bash error on MacOS

### DIFF
--- a/common_utils.sh
+++ b/common_utils.sh
@@ -95,6 +95,10 @@ function gh_clone {
     git clone https://github.com/$1
 }
 
+# gh-clone was renamed to gh_clone, so we have this alias for
+# backwards compatibility.
+alias gh-clone=gh_clone
+
 function set_opts {
     # Set options from input options string (in $- format).
     local opts=$1

--- a/common_utils.sh
+++ b/common_utils.sh
@@ -91,7 +91,7 @@ function is_function {
     (set +e; $(declare -Ff "$1" > /dev/null) && echo true)
 }
 
-function gh-clone {
+function gh_clone {
     git clone https://github.com/$1
 }
 


### PR DESCRIPTION
Fixes https://github.com/matthew-brett/multibuild/issues/259.