### PR TITLE
remove 'm' from python path for 3.8 and up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,7 @@ matrix:
       env:
         - PYTHON_VERSION=3.8
         - VENV=venv
+        - MB_ML_VER=2010
     - os: osx
       env:
         - PYTHON_VERSION=pypy-4.0
@@ -151,6 +152,7 @@ matrix:
       osx_image: xcode10
       env:
         - PYTHON_VERSION=3.8
+        - MB_ML_VER=2010
     - os: osx
       osx_image: xcode10.1
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,6 +80,10 @@ matrix:
         - USE_CCACHE=1
     - os: osx
       env:
+        - PYTHON_VERSION=3.8
+        - VENV=venv
+    - os: osx
+      env:
         - PYTHON_VERSION=pypy-4.0
         - VENV=venv
     - os: osx
@@ -143,6 +147,10 @@ matrix:
       osx_image: xcode10
       env:
         - PYTHON_VERSION=3.7
+    - os: osx
+      osx_image: xcode10
+      env:
+        - PYTHON_VERSION=3.8
     - os: osx
       osx_image: xcode10.1
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,7 @@ matrix:
       env:
         - PYTHON_VERSION=3.8
         - VENV=venv
+        - MB_PYTHON_OSX_VER=10.9
         - MB_ML_VER=2010
     - os: osx
       env:
@@ -152,6 +153,7 @@ matrix:
       osx_image: xcode10
       env:
         - PYTHON_VERSION=3.8
+        - MB_PYTHON_OSX_VER=10.9
         - MB_ML_VER=2010
     - os: osx
       osx_image: xcode10.1

--- a/manylinux_utils.sh
+++ b/manylinux_utils.sh
@@ -19,9 +19,14 @@ function cpython_path {
     #
     # For back-compatibility "u" as u_width also means "32"
     local py_ver="${1:-2.7}"
+    local abi_suff=m
     local u_width="${2:-${UNICODE_WIDTH}}"
     local u_suff=u
-    local m=m
+    # Python 3.8 and up no longer uses the PYMALLOC 'm' suffix
+    # https://github.com/pypa/wheel/pull/303
+    if [ $(lex_ver $py_ver) -ge $(lex_ver 3.8) ]; then
+        abi_suff=""
+    fi
     # Back-compatibility
     if [ "$u_width" == "u" ]; then u_width=32; fi
     # For Python >= 3.4, "u" suffix not meaningful
@@ -32,12 +37,8 @@ function cpython_path {
         echo "Incorrect u_width value $u_width"
         exit 1
     fi
-    # Python 3.8 and up no longer uses the PYMALLOC 'm' suffix
-    if [ $(lex_ver $py_ver) -ge $(lex_ver 3.8) ]; then
-        m=""
-    fi
     local no_dots=$(echo $py_ver | tr -d .)
-    echo "/opt/python/cp${no_dots}-cp${no_dots}$m${u_suff}"
+    echo "/opt/python/cp${no_dots}-cp${no_dots}$abi_suff${u_suff}"
 }
 
 function repair_wheelhouse {

--- a/manylinux_utils.sh
+++ b/manylinux_utils.sh
@@ -21,6 +21,7 @@ function cpython_path {
     local py_ver="${1:-2.7}"
     local u_width="${2:-${UNICODE_WIDTH}}"
     local u_suff=u
+    local m=m
     # Back-compatibility
     if [ "$u_width" == "u" ]; then u_width=32; fi
     # For Python >= 3.4, "u" suffix not meaningful
@@ -31,8 +32,12 @@ function cpython_path {
         echo "Incorrect u_width value $u_width"
         exit 1
     fi
+    # Python 3.8 and up no longer uses the PYMALLOC 'm' suffix
+    if [ $(lex_ver $py_ver) -ge $(lex_ver 3.8) ]; then
+        m=""
+    fi
     local no_dots=$(echo $py_ver | tr -d .)
-    echo "/opt/python/cp${no_dots}-cp${no_dots}m${u_suff}"
+    echo "/opt/python/cp${no_dots}-cp${no_dots}$m${u_suff}"
 }
 
 function repair_wheelhouse {

--- a/osx_utils.sh
+++ b/osx_utils.sh
@@ -21,6 +21,7 @@ LATEST_2p7=2.7.16
 LATEST_3p5=3.5.4
 LATEST_3p6=3.6.8
 LATEST_3p7=3.7.4
+LATEST_3p8=3.8.0rc1
 
 
 function check_python {
@@ -83,6 +84,8 @@ function fill_pyver {
         echo $LATEST_3p6
     elif [ $ver == "3.5" ]; then
         echo $LATEST_3p5
+    elif [ $ver == "3.8" ]; then
+        echo $LATEST_3p8
     else
         echo "Can't fill version $ver" 1>&2
         exit 1


### PR DESCRIPTION
related to gh-261

CPython no longer adds 'm' to the abi tag after  pypa/wheel#303 for python 3.8 and up