### PR TITLE
Add 3.8 tests for linux + mac, make 3.8 the default for mac

### DIFF
--- a/osx_utils.sh
+++ b/osx_utils.sh
@@ -78,14 +78,14 @@ function fill_pyver {
         echo $ver
     elif [ $ver == 2 ] || [ $ver == "2.7" ]; then
         echo $LATEST_2p7
-    elif [ $ver == 3 ] || [ $ver == "3.7" ]; then
+    elif [ $ver == 3 ] || [ $ver == "3.8" ]; then
+        echo $LATEST_3p8
+    elif [ $ver == "3.7" ]; then
         echo $LATEST_3p7
     elif [ $ver == "3.6" ]; then
         echo $LATEST_3p6
     elif [ $ver == "3.5" ]; then
         echo $LATEST_3p5
-    elif [ $ver == "3.8" ]; then
-        echo $LATEST_3p8
     else
         echo "Can't fill version $ver" 1>&2
         exit 1

--- a/tests/test_fill_pyver.sh
+++ b/tests/test_fill_pyver.sh
@@ -2,9 +2,11 @@
 [ "$(fill_pyver 2)" == $LATEST_2p7 ] || ingest
 [ "$(fill_pyver 2.7)" == $LATEST_2p7 ] || ingest
 [ "$(fill_pyver 2.7.8)" == "2.7.8" ] || ingest
-[ "$(fill_pyver 3)" == $LATEST_3p7 ] || ingest
-[ "$(fill_pyver 3.7.0)" == "3.7.0" ] || ingest
+[ "$(fill_pyver 3)" == $LATEST_3p8 ] || ingest
+[ "$(fill_pyver 3.8)" == $LATEST_3p8 ] || ingest
+[ "$(fill_pyver 3.8.0)" == "3.8.0" ] || ingest
 [ "$(fill_pyver 3.7)" == $LATEST_3p7 ] || ingest
+[ "$(fill_pyver 3.7.0)" == "3.7.0" ] || ingest
 [ "$(fill_pyver 3.6)" == $LATEST_3p6 ] || ingest
 [ "$(fill_pyver 3.6.0)" == "3.6.0" ] || ingest
 [ "$(fill_pyver 3.5)" == $LATEST_3p5 ] || ingest

--- a/tests/test_manylinux_utils.sh
+++ b/tests/test_manylinux_utils.sh
@@ -10,3 +10,6 @@
 [ "$(cpython_path 3.7)" == "/opt/python/cp37-cp37m" ] || ingest "cp 3.7"
 [ "$(cpython_path 3.7 32)" == "/opt/python/cp37-cp37m" ] || ingest "cp 3.7 32"
 [ "$(cpython_path 3.7 16)" == "/opt/python/cp37-cp37m" ] || ingest "cp 3.7 16"
+[ "$(cpython_path 3.8)" == "/opt/python/cp38-cp38" ] || ingest "cp 3.8"
+[ "$(cpython_path 3.8 32)" == "/opt/python/cp38-cp38" ] || ingest "cp 3.8 32"
+[ "$(cpython_path 3.8 16)" == "/opt/python/cp38-cp38" ] || ingest "cp 3.8 16"


### PR DESCRIPTION
I was playing with the new 3.8 changes and noticed tests seemed to be incomplete. If someone else is working on this already, my apologies

addresses #261 @mattip 