### PR TITLE
Fix typo in --enable-threadsafe flag

### DIFF
--- a/library_builders.sh
+++ b/library_builders.sh
@@ -227,7 +227,8 @@ function build_hdf5 {
     local short=$(echo $HDF5_VERSION | awk -F "." '{printf "%d.%d", $1, $2}')
     fetch_unpack $hdf5_url/hdf5-$short/hdf5-$HDF5_VERSION/src/hdf5-$HDF5_VERSION.tar.gz
     (cd hdf5-$HDF5_VERSION \
-        && ./configure --with-szlib=$BUILD_PREFIX --prefix=$BUILD_PREFIX --enable-threadsafe \
+        && ./configure --with-szlib=$BUILD_PREFIX --prefix=$BUILD_PREFIX \
+        --enable-threadsafe --enable-unsupported --with-pthread=yes \
         && make -j4 \
         && make install)
     touch hdf5-stamp

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -227,7 +227,7 @@ function build_hdf5 {
     local short=$(echo $HDF5_VERSION | awk -F "." '{printf "%d.%d", $1, $2}')
     fetch_unpack $hdf5_url/hdf5-$short/hdf5-$HDF5_VERSION/src/hdf5-$HDF5_VERSION.tar.gz
     (cd hdf5-$HDF5_VERSION \
-        && ./configure --with-szlib=$BUILD_PREFIX --prefix=$BUILD_PREFIX --enable-thread-safe \
+        && ./configure --with-szlib=$BUILD_PREFIX --prefix=$BUILD_PREFIX --enable-threadsafe \
         && make -j4 \
         && make install)
     touch hdf5-stamp

--- a/tests/test_library_builders.sh
+++ b/tests/test_library_builders.sh
@@ -52,6 +52,7 @@ fi
 suppress build_ragel
 suppress build_cfitsio
 suppress build_new_zlib
+suppress build_hdf5
 
 [ ${MB_PYTHON_VERSION+x} ] || ingest "\$MB_PYTHON_VERSION is not set"
 [ "$MB_PYTHON_VERSION" == "$PYTHON_VERSION" ] || ingest "\$MB_PYTHON_VERSION must be equal to \$PYTHON_VERSION"


### PR DESCRIPTION
This is embarrassing (ref #274):

travis log: https://api.travis-ci.org/v3/job/606358953/log.txt
```
configure: WARNING: unrecognized options: --enable-thread-safe
```

The flag should be: `--enable-threadsafe`: https://support.hdfgroup.org/HDF5/faq/threadsafe.html