### PR TITLE
set MB_PYTHON_OSX_VER default to the newest available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,12 +41,12 @@ matrix:
     # OSX builds
     - os: osx
       env:
-        - PYTHON_VERSION=2.7
+        - MB_PYTHON_VERSION=2.7
         - MB_PYTHON_OSX_VER=10.6
         - TEST_BUILDS=1
     - os: osx
       env:
-        - PYTHON_VERSION=2.7
+        - MB_PYTHON_VERSION=2.7
         - TEST_BUILDS=1
     - os: osx
       language: objective-c
@@ -62,7 +62,7 @@ matrix:
         - VENV=venv
     - os: osx
       env:
-        - PYTHON_VERSION=3.6
+        - MB_PYTHON_VERSION=3.6
         - MB_PYTHON_OSX_VER=10.6
         - VENV=venv
     - os: osx
@@ -71,7 +71,7 @@ matrix:
         - VENV=venv
     - os: osx
       env:
-        - PYTHON_VERSION=3.7
+        - MB_PYTHON_VERSION=3.7
         - MB_PYTHON_OSX_VER=10.6
         - VENV=venv
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,12 +41,12 @@ matrix:
     # OSX builds
     - os: osx
       env:
-        - MB_PYTHON_VERSION=2.7
+        - PYTHON_VERSION=2.7
+        - MB_PYTHON_OSX_VER=10.6
         - TEST_BUILDS=1
     - os: osx
       env:
-        - MB_PYTHON_VERSION=2.7
-        - MB_PYTHON_OSX_VER=10.9
+        - PYTHON_VERSION=2.7
         - TEST_BUILDS=1
     - os: osx
       language: objective-c
@@ -62,22 +62,22 @@ matrix:
         - VENV=venv
     - os: osx
       env:
-        - MB_PYTHON_VERSION=3.6
+        - PYTHON_VERSION=3.6
+        - MB_PYTHON_OSX_VER=10.6
         - VENV=venv
     - os: osx
       env:
         - MB_PYTHON_VERSION=3.6
         - VENV=venv
-        - MB_PYTHON_OSX_VER=10.9
     - os: osx
       env:
-        - MB_PYTHON_VERSION=3.7
+        - PYTHON_VERSION=3.7
+        - MB_PYTHON_OSX_VER=10.6
         - VENV=venv
     - os: osx
       env:
         - MB_PYTHON_VERSION=3.7
         - VENV=venv
-        - MB_PYTHON_OSX_VER=10.9
     - os: osx
       env:
         - MB_PYTHON_VERSION=3.7

--- a/osx_utils.sh
+++ b/osx_utils.sh
@@ -8,12 +8,6 @@ source $MULTIBUILD_DIR/common_utils.sh
 
 MACPYTHON_URL=https://www.python.org/ftp/python
 MACPYTHON_PY_PREFIX=/Library/Frameworks/Python.framework/Versions
-MACPYTHON_DEFAULT_OSX="10.6"
-if [ "$(lex_ver $MB_PYTHON_VERSION)" -ge "$(lex_ver 3.8)" ]; then
-    # At 3.8 Python.org dropped the 10.6 installer.
-    MACPYTHON_DEFAULT_OSX="10.9"
-fi
-MB_PYTHON_OSX_VER=${MB_PYTHON_OSX_VER:-$MACPYTHON_DEFAULT_OSX}
 GET_PIP_URL=https://bootstrap.pypa.io/get-pip.py
 DOWNLOADS_SDIR=downloads
 WORKING_SDIR=working
@@ -96,6 +90,36 @@ function fill_pyver {
     fi
 }
 
+function macpython_sdk_list_for_version {
+    # return a list of SDK targets supported for a given CPython version
+    # Parameters
+    #   $py_version (python version in major.minor.extra format)
+    # eg
+    #  macpython_sdks_for_version 2.7.15
+    #  >> 10.6 10.9
+    local _ver=$(fill_pyver $1)
+    local _major=${_ver%%.*}
+    local _return
+
+    if [ "$_major" -eq "2" ]; then
+        _return="10.6"
+        [ $(lex_ver $_ver) -ge $(lex_ver 2.7.15) ] && _return="$_return 10.9"
+    elif [ "$_major" -eq "3" ]; then
+        [ $(lex_ver $_ver) -lt $(lex_ver 3.8)    ] && _return="10.6"
+        [ $(lex_ver $_ver) -ge $(lex_ver 3.6.5)  ] && _return="$_return 10.9"
+    else
+        echo "Error version=${_ver}, expecting 2.x or 3.x" 1>&2
+        exit 1
+    fi
+    echo $_return
+}
+
+function macpython_sdk_for_version {
+    # assumes the output of macpython_sdk_list_for_version is a list
+    # of SDK vesions XX.Y in sorted order, eg "10.6 10.9" or "10.9"
+    echo $(macpython_sdk_list_for_version $1) | awk -F' ' '{print $NF}'
+}
+
 function pyinst_ext_for_version {
     # echo "pkg" or "dmg" depending on the passed Python version
     # Parameters
@@ -123,13 +147,11 @@ function pyinst_fname_for_version {
     # Parameters
     #   $py_version (Python version in major.minor.extra format)
     #   $py_osx_ver: {major.minor | not defined}
-    #       if defined, the macOS version that Python is built for, e.g.
-    #       "10.6" or "10.9", if not defined, uses the default
-    #       MACPYTHON_DEFAULT_OSX
-    #       Note: this is the version the Python is built for, and hence
-    #       the min version supported, NOT the version of the current system
+    #       if defined, the minimum macOS SDK version that Python is
+    #       built for, eg: "10.6" or "10.9", if not defined, infers
+    #       this from $py_version using macpython_sdk_for_version
     local py_version=$1
-    local py_osx_ver=${2:-$MACPYTHON_DEFAULT_OSX}
+    local py_osx_ver=${2:-$(macpython_sdk_for_version $py_version)}
     local inst_ext=$(pyinst_ext_for_version $py_version)
     echo "python-${py_version}-macosx${py_osx_ver}.${inst_ext}"
 }

--- a/tests/test_multibuild.sh
+++ b/tests/test_multibuild.sh
@@ -9,13 +9,13 @@ source tests/test_fill_submodule.sh
 
 if [ -n "$IS_OSX" ]; then
     source osx_utils.sh
-    MB_PYTHON_OSX_VER=${MB_PYTHON_OSX_VER:-$(macpython_sdk_for_version $PYTHON_VERSION)}
+    MB_PYTHON_OSX_VER=${MB_PYTHON_OSX_VER:-$(macpython_sdk_for_version $MB_PYTHON_VERSION)}
 
     # To work round:
     # https://travis-ci.community/t/syntax-error-unexpected-keyword-rescue-expecting-keyword-end-in-homebrew/5623
     brew update
 
-    get_macpython_environment $PYTHON_VERSION ${VENV:-""} $MB_PYTHON_OSX_VER
+    get_macpython_environment $MB_PYTHON_VERSION ${VENV:-""} $MB_PYTHON_OSX_VER
     source tests/test_python_install.sh
     source tests/test_fill_pyver.sh
     source tests/test_fill_pypy_ver.sh

--- a/tests/test_multibuild.sh
+++ b/tests/test_multibuild.sh
@@ -9,12 +9,13 @@ source tests/test_fill_submodule.sh
 
 if [ -n "$IS_OSX" ]; then
     source osx_utils.sh
+    MB_PYTHON_OSX_VER=${MB_PYTHON_OSX_VER:-$(macpython_sdk_for_version $PYTHON_VERSION)}
 
     # To work round:
     # https://travis-ci.community/t/syntax-error-unexpected-keyword-rescue-expecting-keyword-end-in-homebrew/5623
     brew update
 
-    get_macpython_environment $MB_PYTHON_VERSION ${VENV:-""} $MB_PYTHON_OSX_VER
+    get_macpython_environment $PYTHON_VERSION ${VENV:-""} $MB_PYTHON_OSX_VER
     source tests/test_python_install.sh
     source tests/test_fill_pyver.sh
     source tests/test_fill_pypy_ver.sh

--- a/tests/test_osx_utils.sh
+++ b/tests/test_osx_utils.sh
@@ -9,12 +9,16 @@
 [ "$(pyinst_ext_for_version 3.5)" == pkg ] || ingest
 [ "$(pyinst_ext_for_version 3)" == pkg ] || ingest
 
-macos_ver="${MACPYTHON_DEFAULT_OSX}"
-[ "$(pyinst_fname_for_version 2.7.14)" == "python-2.7.14-macosx${macos_ver}.pkg" ] || ingest
-[ "$(pyinst_fname_for_version 2.7.15)" == "python-2.7.15-macosx${macos_ver}.pkg" ] || ingest
-[ "$(pyinst_fname_for_version 3.6.8)" == "python-3.6.8-macosx${macos_ver}.pkg" ] || ingest
-[ "$(pyinst_fname_for_version 3.7.1)" == "python-3.7.1-macosx${macos_ver}.pkg" ] || ingest
-[ "$(pyinst_fname_for_version 3.8.0)" == "python-3.8.0-macosx${macos_ver}.pkg" ] || ingest
+[ "$(pyinst_fname_for_version 2.7.14)" == "python-2.7.14-macosx10.6.pkg" ] || ingest
+[ "$(pyinst_fname_for_version 2.7.15)" == "python-2.7.15-macosx10.9.pkg" ] || ingest
+[ "$(pyinst_fname_for_version 3.6.8)" == "python-3.6.8-macosx10.9.pkg" ] || ingest
+[ "$(pyinst_fname_for_version 3.7.1)" == "python-3.7.1-macosx10.9.pkg" ] || ingest
+[ "$(pyinst_fname_for_version 3.8.0)" == "python-3.8.0-macosx10.9.pkg" ] || ingest
+
+[ "$(pyinst_fname_for_version 2.7.14 10.6)" == "python-2.7.14-macosx10.6.pkg" ] || ingest
+[ "$(pyinst_fname_for_version 2.7.15 10.6)" == "python-2.7.15-macosx10.6.pkg" ] || ingest
+[ "$(pyinst_fname_for_version 3.6.8 10.6)" == "python-3.6.8-macosx10.6.pkg" ] || ingest
+[ "$(pyinst_fname_for_version 3.7.1 10.6)" == "python-3.7.1-macosx10.6.pkg" ] || ingest
 
 [ "$(pyinst_fname_for_version 2.7.15 10.11)" == "python-2.7.15-macosx10.11.pkg" ] || ingest
 [ "$(pyinst_fname_for_version 3.7.1 10.12)" == "python-3.7.1-macosx10.12.pkg" ] || ingest
@@ -39,6 +43,22 @@ macos_ver="${MACPYTHON_DEFAULT_OSX}"
 [ "$(strip_macpython_ver_prefix pypy-5.4)" == "5.4" ] || ingest
 [ "$(macpython_impl_for_version 3.7.2)" == "cp" ] || ingest
 [ "$(macpython_impl_for_version pypy-5.4)" == "pp" ] || ingest
+
+# Test lookup of available macOS SDK build targets from python version
+[ "$(macpython_sdk_list_for_version 3.8)"    == "10.9" ] || ingest
+[ "$(macpython_sdk_list_for_version 3.7.5)"  == "10.6 10.9" ] || ingest
+[ "$(macpython_sdk_list_for_version 3.7)"    == "10.6 10.9" ] || ingest
+[ "$(macpython_sdk_list_for_version 3.6.5)"  == "10.6 10.9" ] || ingest
+[ "$(macpython_sdk_list_for_version 3.6)"    == "10.6 10.9" ] || ingest
+[ "$(macpython_sdk_list_for_version 3.5)"    == "10.6" ] || ingest
+[ "$(macpython_sdk_list_for_version 2.7)"    == "10.6 10.9" ] || ingest
+[ "$(macpython_sdk_list_for_version 2.7.14)" == "10.6" ] || ingest
+[ "$(macpython_sdk_list_for_version 2.7.15)" == "10.6 10.9" ] || ingest
+
+[ "$(macpython_sdk_for_version 3.8)"    == "10.9" ] || ingest
+[ "$(macpython_sdk_for_version 3.5)"    == "10.6" ] || ingest
+[ "$(macpython_sdk_for_version 2.7)"    == "10.9" ] || ingest
+[ "$(macpython_sdk_for_version 2.7.14)" == "10.6" ] || ingest
 
 # Test pkg-config install
 install_pkg_config

--- a/travis_osx_steps.sh
+++ b/travis_osx_steps.sh
@@ -10,6 +10,8 @@ ENV_VARS_PATH=${ENV_VARS_PATH:-env_vars.sh}
 
 # These load common_utils.sh
 source $MULTIBUILD_DIR/osx_utils.sh
+MB_PYTHON_OSX_VER=${MB_PYTHON_OSX_VER:-$(macpython_sdk_for_version $MB_PYTHON_VERSION)}
+
 if [ -r "$ENV_VARS_PATH" ]; then source "$ENV_VARS_PATH"; fi
 source $MULTIBUILD_DIR/configure_build.sh
 source $MULTIBUILD_DIR/library_builders.sh


### PR DESCRIPTION
default for MB_PYTHON_OSX_VER changed from 10.6 to 10.9 for MB_PYTHON_VERSION 2.7.15+ and 3.6+. This should mean users dont have to explictly set MB_PYTHON_OSX_VER for normal use cases, as most projects only build the latest.

Also adds a new function `macpython_sdk_list_for_version`which could be useful for validating MB_PYTHON_OSX_VER / MB_PYTHON_VERSION combinations in future, rather than just letting the [python.org](python.org) download fail if an invalid combination is chosen

closes #278 