### PR TITLE
Changed bzip2 download URL

### DIFF
--- a/library_builders.sh
+++ b/library_builders.sh
@@ -135,7 +135,7 @@ function build_libpng {
 function build_bzip2 {
     if [ -n "$IS_OSX" ]; then return; fi  # OSX has bzip2 libs already
     if [ -e bzip2-stamp ]; then return; fi
-    fetch_unpack https://download.sourceforge.net/bzip2/bzip2-${BZIP2_VERSION}.tar.gz
+    fetch_unpack https://sourceware.org/pub/bzip2/bzip2-${BZIP2_VERSION}.tar.gz
     (cd bzip2-${BZIP2_VERSION} \
         && make -f Makefile-libbz2_so \
         && make install PREFIX=$BUILD_PREFIX)


### PR DESCRIPTION
https://download.sourceforge.net/bzip2/ only has 1.0.6, while https://sourceware.org/pub/bzip2/, as found at https://sourceware.org/bzip2/, has 1.0.1 through 1.0.8.