### PR TITLE
Warn and exit when no supported wheels are found

### DIFF
--- a/common_utils.sh
+++ b/common_utils.sh
@@ -45,7 +45,7 @@ function stop_spinner {
     if [ ! -n "$MB_SPINNER_PID" ]; then
         return
     fi
-    
+
     kill $MB_SPINNER_PID
     unset MB_SPINNER_PID
 
@@ -335,9 +335,15 @@ function install_wheel {
             pip install $(pip_opts) $@ $TEST_DEPENDENCY
         done <<< "$TEST_DEPENDS"
     fi
+
+    local supported_wheels=$(python $MULTIBUILD_DIR/supported_wheels.py $wheelhouse/*.whl)
+    if [ -z "$supported_wheels" ]; then
+        echo "ERROR: no supported wheels found"
+        exit 1
+    fi
     # Install compatible wheel
-    pip install $(pip_opts) $@ \
-        $(python $MULTIBUILD_DIR/supported_wheels.py $wheelhouse/*.whl)
+    pip install $(pip_opts) $@ $supported_wheels
+
 }
 
 function install_run {

--- a/supported_wheels.py
+++ b/supported_wheels.py
@@ -34,10 +34,10 @@ def main():
         (tag.interpreter, tag.abi, tag.platform) if not isinstance(tag, tuple) else tag
         for tag in get_supported()
     }
-    for fname in sys.argv[1:]:
-        tags = set(tags_for(fname))
-        if supported.intersection(tags):
-            print(fname)
+    # for fname in sys.argv[1:]:
+    #     tags = set(tags_for(fname))
+    #     if supported.intersection(tags):
+    #         print(fname)
 
 
 if __name__ == '__main__':

--- a/supported_wheels.py
+++ b/supported_wheels.py
@@ -34,10 +34,10 @@ def main():
         (tag.interpreter, tag.abi, tag.platform) if not isinstance(tag, tuple) else tag
         for tag in get_supported()
     }
-    # for fname in sys.argv[1:]:
-    #     tags = set(tags_for(fname))
-    #     if supported.intersection(tags):
-    #         print(fname)
+    for fname in sys.argv[1:]:
+        tags = set(tags_for(fname))
+        if supported.intersection(tags):
+            print(fname)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
As of today, when no supported wheels are found, the program fail with the cryptic message:
```
ERROR: You must give at least one requirement to install (maybe you meant "pip install https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com"?)
```

As shown in #300 

Even though the underlying issue has been fixed in #298 , I think having a more meaningful error message could help debugging in the future.