### PR TITLE
Friendly error when curl HTTP errors downloading macOS python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,13 @@ matrix:
       env:
         - MB_PYTHON_VERSION=3.5
         - VENV=venv
+    # this is expected to fail
+    # 3.5 / 10.9 build doesn't exist
+    - os: osx
+      env:
+        - MB_PYTHON_VERSION=3.5
+        - MB_PYTHON_OSX_VER=10.9
+        - OSX_ENV_EXPECT_FAIL=true
     - os: osx
       env:
         - MB_PYTHON_VERSION=3.6

--- a/common_utils.sh
+++ b/common_utils.sh
@@ -141,6 +141,39 @@ function suppress {
     return "$ret"
 }
 
+function expect_return {
+  # Run a command, succeeding (returning 0) only if the commend returns a specified code
+  # Parameters
+  #   retcode   expected return code (which may be zero)
+  #   command   the command called
+  #
+  #   any further arguments are passed to the called command
+  #
+  # Returns 1 if called with less than 2 arguments
+  (( $# < 2 )) && echo "Must have at least 2 arguments" && return 1
+  local retcode=$1
+  local retval
+  ( "${@:2}" ) || retval=$?
+  [[ $retcode == ${retval:-0} ]] && return 0
+  return ${retval:-1}
+}
+
+function cmd_notexit {
+    # wraps a command, capturing its return code and preventing it
+    # from exiting the shell. Handles -e / +e modes.
+    # Parameters
+    #    cmd - command
+    #    any further parameters are passed to the wrapped command
+    # If called without an argument, it will exit the shell with an error
+    local cmd=$1
+    if [ -z "$cmd" ];then echo "no command"; exit 1; fi
+    if [[ $- = *e* ]]; then errexit_set=true; fi
+    set +e
+    ("${@:1}") ; retval=$?
+    [[ -n $errexit_set ]] && set -e
+    return $retval
+}
+
 function rm_mkdir {
     # Remove directory if present, then make directory
     local path=$1

--- a/osx_utils.sh
+++ b/osx_utils.sh
@@ -292,7 +292,7 @@ function install_mac_cpython {
     local inst_path=$DOWNLOADS_SDIR/$py_inst
     local retval=""
     mkdir -p $DOWNLOADS_SDIR
-    # exit early on curl errors, but dont let it exit the shell
+    # exit early on curl errors, but don't let it exit the shell
     cmd_notexit curl -f $MACPYTHON_URL/$py_stripped/${py_inst} > $inst_path || retval=$?
     if [ ${retval:-0} -ne 0 ]; then
       echo "Python download failed! Check ${py_inst} exists on the server."

--- a/osx_utils.sh
+++ b/osx_utils.sh
@@ -290,8 +290,15 @@ function install_mac_cpython {
     local py_stripped=$(strip_ver_suffix $py_version)
     local py_inst=$(pyinst_fname_for_version $py_version $py_osx_ver)
     local inst_path=$DOWNLOADS_SDIR/$py_inst
+    local retval=""
     mkdir -p $DOWNLOADS_SDIR
-    curl $MACPYTHON_URL/$py_stripped/${py_inst} > $inst_path
+    # exit early on curl errors, but dont let it exit the shell
+    cmd_notexit curl -f $MACPYTHON_URL/$py_stripped/${py_inst} > $inst_path || retval=$?
+    if [ ${retval:-0} -ne 0 ]; then
+      echo "Python download failed! Check ${py_inst} exists on the server."
+      exit $retval
+    fi
+
     if [ "${py_inst: -3}" == "dmg" ]; then
         hdiutil attach $inst_path -mountpoint /Volumes/Python
         inst_path=/Volumes/Python/Python.mpkg

--- a/tests/test_common_utils.sh
+++ b/tests/test_common_utils.sh
@@ -88,6 +88,17 @@ actual="$(set -e; suppress bad_mid_cmd)"
 # Reset options
 set_opts $ORIG_OPTS
 
+! expect_return 1 || ingest "Too few arguments"
+! expect_return 1 good_cmd || ingest "unexpected success"
+! expect_return 0 bad_cmd || ingest "unexpected failure"
+expect_return 1 bad_cmd || ingest "fail with expected error 1"
+! expect_return 2 bad_cmd || ingest "fail with unexpected error"
+expect_return 0 good_cmd || ingest "succeed as expected"
+
+cmd_notexit good_cmd || ingest
+! cmd_notexit bad_cmd || ingest
+! cmd_notexit exit 1 || ingest
+
 # On Linux docker containers in travis, can be x86_64, i686, s390x, ppc64le, or
 # aarch64
 [ "$(get_platform)" == x86_64 ] || \

--- a/tests/test_multibuild.sh
+++ b/tests/test_multibuild.sh
@@ -21,7 +21,13 @@ if [ -n "$IS_MACOS" ]; then
     MB_PYTHON_OSX_VER=${MB_PYTHON_OSX_VER:-$(macpython_sdk_for_version $MB_PYTHON_VERSION)}
     PLAT=${PLAT:-$(macpython_arch_for_version $MB_PYTHON_VERSION)}
 
+    # exit early if this cmd is expected to fail (and does)
+    if [[ -n $OSX_ENV_EXPECT_FAIL ]]; then
+      expect_return 22 get_macpython_environment $MB_PYTHON_VERSION ${VENV:-""} $MB_PYTHON_OSX_VER
+      exit 0
+    fi
     get_macpython_environment $MB_PYTHON_VERSION ${VENV:-""} $MB_PYTHON_OSX_VER
+
     source tests/test_python_install.sh
     source tests/test_fill_pyver.sh
     source tests/test_fill_pypy_ver.sh


### PR DESCRIPTION
probably means a bad python version was specified
add an ‘expected fail’ test to the matrix to exercise this case

closes #293 