### PR TITLE
allow choosing the test docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ matrix:
       env:
         - TEST_BUILDS=1
         - MB_ML_VER=2010
+        - MB_TEST_VER=multibuild/xenial
     # 32-bit builds
     - os: linux
       dist: xenial
@@ -38,6 +39,7 @@ matrix:
         - TEST_BUILDS=1
         - PLAT=i686
         - MB_ML_VER=2010
+        - MB_TEST_VER=multibuild/bionic
     # Builds with caching
     - os: linux
       dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
       env:
         - TEST_BUILDS=1
         - MB_ML_VER=2010
-        - DOCKER_TEST_IMAGE=multibuild/xenial64
+        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
     # 32-bit builds
     - os: linux
       dist: xenial
@@ -39,7 +39,7 @@ matrix:
         - TEST_BUILDS=1
         - PLAT=i686
         - MB_ML_VER=2010
-        - DOCKER_TEST_IMAGE=multibuild/bionic32
+        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
     # Builds with caching
     - os: linux
       dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ matrix:
         - MB_PYTHON_VERSION=pypy3.6-7.3
         - MB_ML_VER=2014
         - TEST_BUILDS=1
+        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
     # OSX builds
     - os: osx
       env:
@@ -103,19 +104,7 @@ matrix:
         - VENV=venv
     - os: osx
       env:
-        - MB_PYTHON_VERSION=pypy-6.0
-        - VENV=venv
-    - os: osx
-      env:
-        - MB_PYTHON_VERSION=pypy-7.0
-        - VENV=venv
-    - os: osx
-      env:
-        - MB_PYTHON_VERSION=pypy-7.1
-        - VENV=venv
-    - os: osx
-      env:
-        - MB_PYTHON_VERSION=pypy-7.2
+        - MB_PYTHON_VERSION=pypy-7.3
         - TEST_BUILDS=1
         - VENV=venv
     # Default OSX (xcode image) is 10.13 (xcode 9.4.1) as of 2018-08-03

--- a/.travis.yml
+++ b/.travis.yml
@@ -195,6 +195,7 @@ matrix:
         - MB_ML_VER=2014
         - TEST_BUILDS=1
         - PLAT=aarch64
+        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
     #  s390x builds
     - os: linux
       arch: s390x
@@ -203,6 +204,7 @@ matrix:
         - MB_ML_VER=2014
         - TEST_BUILDS=1
         - PLAT=s390x
+        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
     #  ppc64le builds
     - os: linux
       arch: ppc64le
@@ -211,6 +213,7 @@ matrix:
         - MB_ML_VER=2014
         - TEST_BUILDS=1
         - PLAT=ppc64le
+        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
 
 script:
   - export ENV_VARS_PATH="tests/env_vars.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
       env:
         - TEST_BUILDS=1
         - MB_ML_VER=2010
-        - MB_TEST_VER=multibuild/xenial
+        - DOCKER_TEST_IMAGE=multibuild/xenial64
     # 32-bit builds
     - os: linux
       dist: xenial
@@ -39,7 +39,7 @@ matrix:
         - TEST_BUILDS=1
         - PLAT=i686
         - MB_ML_VER=2010
-        - MB_TEST_VER=multibuild/bionic
+        - DOCKER_TEST_IMAGE=multibuild/bionic32
     # Builds with caching
     - os: linux
       dist: xenial

--- a/README.rst
+++ b/README.rst
@@ -125,12 +125,18 @@ real ``build_wheel`` function, which now comes (by default) from
 Test phase
 ----------
 
-Specify the version to test with the ``DOCKER_TEST_IMAGE`` environment variable. The
-default version is ``matthewbrett/trusty:64``, or for ``i686`` platforms
-``matthewbrett/trusty:32``. Other versions that are currently valid are:
+Specify the version to test with the ``DOCKER_TEST_IMAGE`` environment
+variable. The default version is dependent on ``PLAT``:
 
-* ``multibuild/bionic32`` (32 only)
-* ``multibuild/xenial64`` (64 only)
+* ``matthewbrett/trusty:64``, for ``x86_64``
+* ``matthewbrett/trusty:32`` for ``i686``
+* ``multibuild/xenial_arm64v8`` for ``aarch64``
+* ``multibuild/xenial_ppc64le`` for ``ppc64le``
+* ``mutlibuild/xenial_s390x`` for ``s390x``
+
+Other valid values are any in https://hub.docker.com/orgs/multibuild/repositories,
+using the correct platform code. Alternatively, you can use the substitution
+pattern ``multibuild/xenial_{PLAT}`` in the ``.travis.yml`` file.
 
 See ``multibuild/docker_test_wrap.sh``.
 

--- a/README.rst
+++ b/README.rst
@@ -125,14 +125,12 @@ real ``build_wheel`` function, which now comes (by default) from
 Test phase
 ----------
 
-Specify the version to test with the ``MB_TEST_VER`` environment variable. The
-default version is ``matthewbrett/trusty:``. A suffix will be added by the
-``PLAT`` choice: ``i686`` will add ``32``, all others will add ``64``.
-Versions that are currently valid are:
+Specify the version to test with the ``DOCKER_TEST_IMAGE`` environment variable. The
+default version is ``matthewbrett/trusty:64``, or for ``i686`` platforms
+``matthewbrett/trusty:32``. Other versions that are currently valid are:
 
-* ``matthewbrett/trusty:`` (32 or 64)
-* ``multibuild/bionic`` (32 only)
-* ``multibuild/xenial`` (64 only)
+* ``multibuild/bionic32`` (32 only)
+* ``multibuild/xenial64`` (64 only)
 
 See ``multibuild/docker_test_wrap.sh``.
 

--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ The AppVeyor setup is designed to build *and test*:
 * 64-bit Windows ``win_amd64`` wheels
 * 32-bit Windows ``win32`` wheels
 
-You can currently build and test against Pythons 2.7, 3.5, 3.6, 3.7.
+You can currently build and test against Pythons 2.7, 3.5, 3.6, 3.7, 3.8
 
 *****************
 How does it work?
@@ -78,7 +78,7 @@ Manylinux
 =========
 
 The build phase is in a Manylinux Docker container, but the test phase is in
-a clean Ubuntu 14.04 container.
+a clean container.
 
 
 Build phase
@@ -125,11 +125,21 @@ real ``build_wheel`` function, which now comes (by default) from
 Test phase
 ----------
 
-Testing is in an Ubuntu 14.04 Docker container - see
-``multibuild/docker_test_wrap.sh``.  ``multibuild/travis_linux_steps.sh``
-defines the ``install_run`` function, which starts up the testing Docker
-container with a wrapper script ``multibuild/docker_test_wrap.sh``.  The
-wrapper script sources the following bash scripts::
+Specify the version to test with the ``MB_TEST_VER`` environment variable. The
+default version is ``matthewbrett/trusty:``. A suffix will be added by the
+``PLAT`` choice: ``i686`` will add ``32``, all others will add ``64``.
+Versions that are currently valid are:
+
+* ``matthewbrett/trusty:`` (32 or 64)
+* ``multibuild/bionic`` (32 only)
+* ``multibuild/xenial`` (64 only)
+
+See ``multibuild/docker_test_wrap.sh``.
+
+``multibuild/travis_linux_steps.sh`` defines the ``install_run`` function,
+which starts up the testing Docker container with the wrapper script
+``multibuild/docker_test_wrap.sh``. The wrapper script sources the following
+bash scripts::
 
     multibuild/common_utils.sh
     config.sh

--- a/common_utils.sh
+++ b/common_utils.sh
@@ -458,6 +458,7 @@ function install_pypy {
     fi
     PYTHON_EXE=$(realpath $py_build/bin/pypy)
     $PYTHON_EXE -mensurepip
+    $PYTHON_EXE -mpip install --upgrade pip setuptools wheel
     if [ "$major" == "3" ] && [ ! -x "$py_build/bin/pip" ]; then
         ln $py_build/bin/pip3 $py_build/bin/pip
     fi
@@ -560,4 +561,31 @@ function get_py_mm {
     $PYTHON_EXE -c "import sys; print('{0}.{1}'.format(*sys.version_info[0:2]))"
 }
 
-
+function cpython_path {
+    # Return path to cpython given
+    # * version (of form "2.7")
+    # * u_width ("16" or "32" default "32")
+    #
+    # For back-compatibility "u" as u_width also means "32"
+    local py_ver="${1:-2.7}"
+    local abi_suff=m
+    local u_width="${2:-${UNICODE_WIDTH}}"
+    local u_suff=u
+    # Python 3.8 and up no longer uses the PYMALLOC 'm' suffix
+    # https://github.com/pypa/wheel/pull/303
+    if [ $(lex_ver $py_ver) -ge $(lex_ver 3.8) ]; then
+        abi_suff=""
+    fi
+    # Back-compatibility
+    if [ "$u_width" == "u" ]; then u_width=32; fi
+    # For Python >= 3.4, "u" suffix not meaningful
+    if [ $(lex_ver $py_ver) -ge $(lex_ver 3.4) ] ||
+        [ "$u_width" == "16" ]; then
+        u_suff=""
+    elif [ "$u_width" != "32" ]; then
+        echo "Incorrect u_width value $u_width"
+        exit 1
+    fi
+    local no_dots=$(echo $py_ver | tr -d .)
+    echo "/opt/python/cp${no_dots}-cp${no_dots}$abi_suff${u_suff}"
+}

--- a/common_utils.sh
+++ b/common_utils.sh
@@ -333,17 +333,22 @@ function install_wheel {
     #     WHEEL_SDIR  (optional, default "wheelhouse")
     #     TEST_DEPENDS  (optional, default "")
     #     MANYLINUX_URL (optional, default "") (via pip_opts function)
+    set -x
     local wheelhouse=$(abspath ${WHEEL_SDIR:-wheelhouse})
     if [ -n "$TEST_DEPENDS" ]; then
         while read TEST_DEPENDENCY; do
             pip install $(pip_opts) $@ $TEST_DEPENDENCY
         done <<< "$TEST_DEPENDS"
     fi
-
+    ls .
+    which pip
+    which python
     pip install packaging
+    get_platform
     local supported_wheels=$(python $MULTIBUILD_DIR/supported_wheels.py $wheelhouse/*.whl)
     if [ -z "$supported_wheels" ]; then
         echo "ERROR: no supported wheels found"
+        ls $wheelhouse/*.whl
         exit 1
     fi
     # Install compatible wheel

--- a/common_utils.sh
+++ b/common_utils.sh
@@ -582,7 +582,7 @@ function cpython_path {
     if [ $(lex_ver $py_ver) -ge $(lex_ver 3.4) ] ||
         [ "$u_width" == "16" ]; then
         u_suff=""
-    elif [ "$u_width" == ""]; then
+    elif [ "$u_width" == "" ]; then
         u_width="32"
     elif [ "$u_width" != "32" ]; then
         echo "Incorrect u_width value $u_width"

--- a/common_utils.sh
+++ b/common_utils.sh
@@ -333,18 +333,13 @@ function install_wheel {
     #     WHEEL_SDIR  (optional, default "wheelhouse")
     #     TEST_DEPENDS  (optional, default "")
     #     MANYLINUX_URL (optional, default "") (via pip_opts function)
-    set -x
     local wheelhouse=$(abspath ${WHEEL_SDIR:-wheelhouse})
     if [ -n "$TEST_DEPENDS" ]; then
         while read TEST_DEPENDENCY; do
-            pip install $(pip_opts) $@ $TEST_DEPENDENCY
+            python -mpip install $(pip_opts) $@ $TEST_DEPENDENCY
         done <<< "$TEST_DEPENDS"
     fi
-    ls .
-    which pip
-    which python
-    pip install packaging
-    get_platform
+    python -mpip install packaging
     local supported_wheels=$(python $MULTIBUILD_DIR/supported_wheels.py $wheelhouse/*.whl)
     if [ -z "$supported_wheels" ]; then
         echo "ERROR: no supported wheels found"
@@ -352,7 +347,7 @@ function install_wheel {
         exit 1
     fi
     # Install compatible wheel
-    pip install $(pip_opts) $@ $supported_wheels
+    python -mpip install $(pip_opts) $@ $supported_wheels
 }
 
 function install_run {

--- a/common_utils.sh
+++ b/common_utils.sh
@@ -336,18 +336,18 @@ function install_wheel {
     local wheelhouse=$(abspath ${WHEEL_SDIR:-wheelhouse})
     if [ -n "$TEST_DEPENDS" ]; then
         while read TEST_DEPENDENCY; do
-            python -mpip install $(pip_opts) $@ $TEST_DEPENDENCY
+            $PYTHON_EXE -mpip install $(pip_opts) $@ $TEST_DEPENDENCY
         done <<< "$TEST_DEPENDS"
     fi
-    python -mpip install packaging
-    local supported_wheels=$(python $MULTIBUILD_DIR/supported_wheels.py $wheelhouse/*.whl)
+    $PYTHON_EXE -mpip install packaging
+    local supported_wheels=$($PYTHON_EXE $MULTIBUILD_DIR/supported_wheels.py $wheelhouse/*.whl)
     if [ -z "$supported_wheels" ]; then
         echo "ERROR: no supported wheels found"
         ls $wheelhouse/*.whl
         exit 1
     fi
     # Install compatible wheel
-    python -mpip install $(pip_opts) $@ $supported_wheels
+    $PYTHON_EXE -mpip install $(pip_opts) $@ $supported_wheels
 }
 
 function install_run {

--- a/common_utils.sh
+++ b/common_utils.sh
@@ -16,6 +16,12 @@ DOWNLOADS_SDIR=downloads
 PYPY_URL=https://bitbucket.org/pypy/pypy/downloads
 GET_PIP_URL=https://bootstrap.pypa.io/get-pip.py
 
+# Unicode width, default 32. Used here and in travis_linux_steps.sh
+# In docker_build_wrap.sh it is passed in when calling "docker run"
+# The docker test images also use it when choosing the python to run
+# with, so it is passed in when calling "docker run" for tests.
+UNICODE_WIDTH=${UNICODE_WIDTH:-32}
+
 if [ $(uname) == "Darwin" ]; then IS_OSX=1; fi
 
 # Work round bug in travis xcode image described at
@@ -343,7 +349,6 @@ function install_wheel {
     local supported_wheels=$($PYTHON_EXE $MULTIBUILD_DIR/supported_wheels.py $wheelhouse/*.whl)
     if [ -z "$supported_wheels" ]; then
         echo "ERROR: no supported wheels found"
-        ls $wheelhouse/*.whl
         exit 1
     fi
     # Install compatible wheel

--- a/common_utils.sh
+++ b/common_utils.sh
@@ -582,6 +582,8 @@ function cpython_path {
     if [ $(lex_ver $py_ver) -ge $(lex_ver 3.4) ] ||
         [ "$u_width" == "16" ]; then
         u_suff=""
+    elif [ "$u_width" == ""]; then
+        u_width="32"
     elif [ "$u_width" != "32" ]; then
         echo "Incorrect u_width value $u_width"
         exit 1

--- a/docker_build_wrap.sh
+++ b/docker_build_wrap.sh
@@ -11,9 +11,6 @@ set -e
 # Change into root directory of repo
 cd /io
 
-# Unicode width, default 32
-UNICODE_WIDTH=${UNICODE_WIDTH:-32}
-
 # Location of wheels, default "wheelhouse"
 WHEEL_SDIR=${WHEEL_SDIR:-wheelhouse}
 

--- a/docker_test_wrap.sh
+++ b/docker_test_wrap.sh
@@ -2,6 +2,13 @@
 # Install and test steps on Linux
 set -e
 
+# "python" and "pip" are already on the path as part of the docker
+# startup code in choose_python.sh, but the following are required and not
+# necessarily already set
+
+PYTHON_EXE=${PYTHON_EXE:-python}
+PIP_CMD=${PIP_CMD:-pip}
+
 # Get needed utilities
 MULTIBUILD_DIR=$(dirname "${BASH_SOURCE[0]}")
 source $MULTIBUILD_DIR/common_utils.sh

--- a/manylinux_utils.sh
+++ b/manylinux_utils.sh
@@ -4,41 +4,9 @@
 MULTIBUILD_DIR=$(dirname "${BASH_SOURCE[0]}")
 source $MULTIBUILD_DIR/common_utils.sh
 
-# UNICODE_WIDTH selects "32"=wide (UCS4) or "16"=narrow (UCS2/UTF16) builds
-UNICODE_WIDTH="${UNICODE_WIDTH:-32}"
-
 function get_platform {
     # Report platform as given by uname
     python -c 'import platform; print(platform.uname()[4])'
-}
-
-function cpython_path {
-    # Return path to cpython given
-    # * version (of form "2.7")
-    # * u_width ("16" or "32" default "32")
-    #
-    # For back-compatibility "u" as u_width also means "32"
-    local py_ver="${1:-2.7}"
-    local abi_suff=m
-    local u_width="${2:-${UNICODE_WIDTH}}"
-    local u_suff=u
-    # Python 3.8 and up no longer uses the PYMALLOC 'm' suffix
-    # https://github.com/pypa/wheel/pull/303
-    if [ $(lex_ver $py_ver) -ge $(lex_ver 3.8) ]; then
-        abi_suff=""
-    fi
-    # Back-compatibility
-    if [ "$u_width" == "u" ]; then u_width=32; fi
-    # For Python >= 3.4, "u" suffix not meaningful
-    if [ $(lex_ver $py_ver) -ge $(lex_ver 3.4) ] ||
-        [ "$u_width" == "16" ]; then
-        u_suff=""
-    elif [ "$u_width" != "32" ]; then
-        echo "Incorrect u_width value $u_width"
-        exit 1
-    fi
-    local no_dots=$(echo $py_ver | tr -d .)
-    echo "/opt/python/cp${no_dots}-cp${no_dots}$abi_suff${u_suff}"
 }
 
 function repair_wheelhouse {

--- a/supported_wheels.py
+++ b/supported_wheels.py
@@ -34,6 +34,5 @@ def main():
         if supported.intersection(tags):
             print(fname)
 
-
 if __name__ == '__main__':
     main()

--- a/tests/config.sh
+++ b/tests/config.sh
@@ -1,4 +1,4 @@
 function run_tests {
-    python -c "import simplejson"
+    $PYTHON_EXE -c "import simplejson"
 }
 

--- a/tests/config.sh
+++ b/tests/config.sh
@@ -1,0 +1,4 @@
+function run_tests {
+    python -c "import simplejson"
+}
+

--- a/tests/test_multibuild.sh
+++ b/tests/test_multibuild.sh
@@ -43,6 +43,9 @@ if [ -n "$TEST_BUILDS" ]; then
         "
         build_multilinux $my_plat "pip install simplejson"
     fi
+    build_index_wheel simplejson
+    CONFIG_PATH=tests/config.sh
+    install_run $PLAT
 fi
 
 source tests/test_supported_wheels.sh

--- a/tests/test_multibuild.sh
+++ b/tests/test_multibuild.sh
@@ -31,6 +31,7 @@ if [ -n "$TEST_BUILDS" ]; then
         # Will be set automatically by docker call in build_multilinux below.
         PYTHON_VERSION=${MB_PYTHON_VERSION}
         source tests/test_library_builders.sh
+        source tests/config.sh
     elif [ ! -x "$(command -v docker)" ]; then
         echo "Skipping build tests; no docker available"
     else
@@ -42,9 +43,9 @@ if [ -n "$TEST_BUILDS" ]; then
             source tests/test_library_builders.sh
         "
         build_multilinux $my_plat "pip install simplejson"
+        CONFIG_PATH=tests/config.sh
     fi
     build_index_wheel simplejson
-    CONFIG_PATH=tests/config.sh
     install_run $PLAT
 fi
 

--- a/travis_linux_steps.sh
+++ b/travis_linux_steps.sh
@@ -121,12 +121,13 @@ function install_run {
     #  TEST_DEPENDS  (optional)
     #  MB_TEST_VER (optional)
     local plat=${1:-${PLAT:-x86_64}}
-    local mb_test_ver=${DOCKER_TEST_IMAGE:-"matthewbrett/trusty:"}
     if [ -z "$DOCKER_TEST_IMAGE" ]; then
         local bitness=$([ "$plat" == i686 ] && echo 32 || echo 64)
         local docker_image="matthewbrett/trusty:$bitness"
     else
-        local docker_image=$DOCKER_TEST_IMAGE
+        # aarch64 is called arm64v8 in Ubuntu
+        local plat_subst=$([ "$plat" == aarch64 ] && echo arm64v8 || echo $plat)
+        local docker_image="${DOCKER_TEST_IMAGE/\{plat_subst\}/$plat_subst}"
     fi
     docker pull $docker_image
     docker run --rm \

--- a/travis_linux_steps.sh
+++ b/travis_linux_steps.sh
@@ -121,9 +121,13 @@ function install_run {
     #  TEST_DEPENDS  (optional)
     #  MB_TEST_VER (optional)
     local plat=${1:-${PLAT:-x86_64}}
-    local mb_test_ver=${MB_TEST_VER:-"matthewbrett/trusty:"}
-    bitness=$([ "$plat" == i686 ] && echo 32 || echo 64)
-    local docker_image=$mb_test_ver$bitness
+    local mb_test_ver=${DOCKER_TEST_IMAGE:-"matthewbrett/trusty:"}
+    if [ -z "$DOCKER_TEST_IMAGE" ]; then
+        local bitness=$([ "$plat" == i686 ] && echo 32 || echo 64)
+        local docker_image="matthewbrett/trusty:$bitness"
+    else
+        local docker_image=$DOCKER_TEST_IMAGE
+    fi
     docker pull $docker_image
     docker run --rm \
         -e PYTHON_VERSION="$MB_PYTHON_VERSION" \

--- a/travis_linux_steps.sh
+++ b/travis_linux_steps.sh
@@ -119,9 +119,11 @@ function install_run {
     #  WHEEL_SDIR (optional)
     #  MANYLINUX_URL (optional)
     #  TEST_DEPENDS  (optional)
+    #  MB_TEST_VER (optional)
     local plat=${1:-${PLAT:-x86_64}}
+    local mb_test_ver=${MB_TEST_VER:-"matthewbrett/trusty:"}
     bitness=$([ "$plat" == i686 ] && echo 32 || echo 64)
-    local docker_image="matthewbrett/trusty:$bitness"
+    local docker_image=$mb_test_ver$bitness
     docker pull $docker_image
     docker run --rm \
         -e PYTHON_VERSION="$MB_PYTHON_VERSION" \

--- a/travis_linux_steps.sh
+++ b/travis_linux_steps.sh
@@ -127,7 +127,7 @@ function install_run {
     else
         # aarch64 is called arm64v8 in Ubuntu
         local plat_subst=$([ "$plat" == aarch64 ] && echo arm64v8 || echo $plat)
-        local docker_image="${DOCKER_TEST_IMAGE/\{plat_subst\}/$plat_subst}"
+        local docker_image="${DOCKER_TEST_IMAGE/\{PLAT\}/$plat_subst}"
     fi
     docker pull $docker_image
     docker run --rm \


### PR DESCRIPTION
I opened a new github org multi-build to hold recipes for new docker images for testing, and pushed a few to the dockerhub organization "multibuild". This PR adds an option to use them, and modifies 2 CI runs.

If this looks good, I can push more images to docker hub: xenial32 and bionic64, maybe reproduce the trusty ones too?