### PR TITLE
remove brew update to avoid problems with older macos images

### DIFF
--- a/tests/test_multibuild.sh
+++ b/tests/test_multibuild.sh
@@ -11,11 +11,6 @@ if [ -n "$IS_OSX" ]; then
     source osx_utils.sh
     MB_PYTHON_OSX_VER=${MB_PYTHON_OSX_VER:-$(macpython_sdk_for_version $MB_PYTHON_VERSION)}
 
-    brew tap homebrew/homebrew-core
-    # To work round:
-    # https://travis-ci.community/t/syntax-error-unexpected-keyword-rescue-expecting-keyword-end-in-homebrew/5623
-    brew update
-
     get_macpython_environment $MB_PYTHON_VERSION ${VENV:-""} $MB_PYTHON_OSX_VER
     source tests/test_python_install.sh
     source tests/test_fill_pyver.sh

--- a/tests/test_multibuild.sh
+++ b/tests/test_multibuild.sh
@@ -11,6 +11,7 @@ if [ -n "$IS_OSX" ]; then
     source osx_utils.sh
     MB_PYTHON_OSX_VER=${MB_PYTHON_OSX_VER:-$(macpython_sdk_for_version $MB_PYTHON_VERSION)}
 
+    brew tap homebrew/homebrew-core
     # To work round:
     # https://travis-ci.community/t/syntax-error-unexpected-keyword-rescue-expecting-keyword-end-in-homebrew/5623
     brew update


### PR DESCRIPTION
removing `brew update` seems to fix #320  but is there something Im missing here?
why would it only fail on the Xcode8 and Xcode 7.3 images?