### PR TITLE
Fixes for install_pypy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,11 @@ matrix:
         - MB_PYTHON_VERSION=2.7
         - TEST_BUILDS=1
     - os: osx
+      env:
+        - MB_PYTHON_VERSION=pypy3.6-7.3
+        - MB_PYTHON_OSX_VER=10.9
+        - TEST_BUILDS=1
+    - os: osx
       language: objective-c
       env:
         - MB_PYTHON_VERSION=2.7

--- a/common_utils.sh
+++ b/common_utils.sh
@@ -440,7 +440,6 @@ function install_pypy {
     # sets $PYTHON_EXE variable to python executable
 
     local version=$1
-    suffix=linux64
     case "$PLAT" in
     "x86_64")  suffix="linux64";;
     "i686")    suffix="linux32";;

--- a/common_utils.sh
+++ b/common_utils.sh
@@ -440,19 +440,18 @@ function install_pypy {
     # sets $PYTHON_EXE variable to python executable
 
     local version=$1
-    case "$PLAT" in
-    "x86_64")  suffix="linux64";;
-    "i686")    suffix="linux32";;
-    "darwin")  suffix="osx64";;
-    "ppc64le") suffix="ppc64le";;
-    "s390x")    suffix="s390x";;
-    "aarch64")  suffix="aarch64";;
-    *) if [ -n "$IS_OSX" ]; then
-            suffix="osx64";
-       else
-            echo unknown platform "$PLAT"; exit 1
-       fi;;
-    esac
+    if [ -n "$IS_OSX" ]; then
+       suffix="osx64"
+    else
+       case "$PLAT" in
+       "x86_64")  suffix="linux64";;
+       "i686")    suffix="linux32";;
+       "ppc64le") suffix="ppc64le";;
+       "s390x")   suffix="s390x";;
+       "aarch64") suffix="aarch64";;
+       *) echo unknown platform "$PLAT"; exit 1;;
+       esac
+    fi
 
     # Need to convert pypy-7.2 to pypy2.7-v7.2.0 and pypy3.6-7.3 to pypy3.6-v7.3.0
     local prefix=$(get_pypy_build_prefix $version)

--- a/common_utils.sh
+++ b/common_utils.sh
@@ -440,18 +440,18 @@ function install_pypy {
     # sets $PYTHON_EXE variable to python executable
 
     local version=$1
-    if [ -n "$IS_OSX" ]; then
-       suffix="osx64"
-    else
-       case "$PLAT" in
-       "x86_64")  suffix="linux64";;
-       "i686")    suffix="linux32";;
-       "ppc64le") suffix="ppc64le";;
-       "s390x")   suffix="s390x";;
-       "aarch64") suffix="aarch64";;
-       *) echo unknown platform "$PLAT"; exit 1;;
-       esac
-    fi
+    case "$PLAT" in
+    "x86_64")  if [ -n "$IS_OSX" ]; then
+                   suffix="osx64";
+               else
+                   suffix="linux64";
+               fi;;
+    "i686")    suffix="linux32";;
+    "ppc64le") suffix="ppc64le";;
+    "s390x")    suffix="s390x";;
+    "aarch64")  suffix="aarch64";;
+    *) echo unknown platform "$PLAT"; exit 1;;
+    esac
 
     # Need to convert pypy-7.2 to pypy2.7-v7.2.0 and pypy3.6-7.3 to pypy3.6-v7.3.0
     local prefix=$(get_pypy_build_prefix $version)

--- a/common_utils.sh
+++ b/common_utils.sh
@@ -446,7 +446,7 @@ function install_pypy {
     "i686")    suffix="linux32";;
     "darwin")  suffix="osx64";;
     "ppc64le") suffix="ppc64le";;
-    "s30x")    suffix="s390x";;
+    "s390x")    suffix="s390x";;
     "aarch64")  suffix="aarch64";;
     *) if [ -n "$IS_OSX" ]; then
             suffix="osx64";

--- a/tests/test_multibuild.sh
+++ b/tests/test_multibuild.sh
@@ -19,6 +19,7 @@ unset PYTHON_EXE
 if [ -n "$IS_OSX" ]; then
     source osx_utils.sh
     MB_PYTHON_OSX_VER=${MB_PYTHON_OSX_VER:-$(macpython_sdk_for_version $MB_PYTHON_VERSION)}
+    PLAT=${PLAT:-$(macpython_arch_for_version $MB_PYTHON_VERSION)}
 
     get_macpython_environment $MB_PYTHON_VERSION ${VENV:-""} $MB_PYTHON_OSX_VER
     source tests/test_python_install.sh

--- a/tests/test_python_install.sh
+++ b/tests/test_python_install.sh
@@ -52,8 +52,14 @@ if [ -n "$VENV" ]; then  # in virtualenv
         ingest "Wrong virtualenv pip '$PIP_CMD'"
     fi
 else # not virtualenv
-    macpie_bin="$MACPYTHON_PY_PREFIX/$python_mm/bin"
-    if [ "$PYTHON_EXE" != "$macpie_bin/python$python_mm" ]; then
+    if [[ $requested_impl == 'cp' ]]; then
+        macpie_bin="$MACPYTHON_PY_PREFIX/$python_mm/bin"
+        bin_name="python$python_mm"
+    else
+        macpie_bin="$PWD/pypy$python_mm-v$implementer_version-osx64/bin"
+        bin_name="pypy"
+    fi
+    if [ "$PYTHON_EXE" != "$macpie_bin/$bin_name" ]; then
         ingest "Wrong macpython python cmd '$PYTHON_EXE'"
     fi
     if [ "$PIP_CMD" != "sudo $macpie_bin/pip${python_mm}${expected_pip_args}" ]; then

--- a/tests/test_python_install.sh
+++ b/tests/test_python_install.sh
@@ -23,7 +23,7 @@ fi
 python_mm="${cpython_version:0:1}.${cpython_version:2:1}"
 
 # extract implementation prefix and version
-if [[ "$MB_PYTHON_VERSION" =~ (pypy-)?([0-9\.]+) ]]; then
+if [[ "$MB_PYTHON_VERSION" =~ (pypy[0-9\.]*-)?([0-9\.]+) ]]; then
     _impl=${BASH_REMATCH[1]:-"cp"}
     requested_impl=${_impl:0:2}
     requested_version=${BASH_REMATCH[2]}


### PR DESCRIPTION
**Minor changes**
- Fixes a typo - "s30x"
- Removes the default `suffix` value, since the default switch case throws an error, so that the default value is never used.

**The main change**

The README states that

> The PLAT environment variable can be one of x86_64, i686 s390x, ppc64le, or aarch64

It doesn't mention "darwin", which `install_pypy` currently checks for. Instead of checking for PLAT at all on macOS, this PR changes to just using IS_OSX.

cc @mattip since they wrote this code and may have thoughts on this