### PR TITLE
Fixed running test_library_builders for build_multilinux

### DIFF
--- a/tests/test_multibuild.sh
+++ b/tests/test_multibuild.sh
@@ -43,10 +43,8 @@ if [ -n "$TEST_BUILDS" ]; then
         touch config.sh
         source travis_linux_steps.sh
         my_plat=${PLAT:-x86_64}
-        build_multilinux $my_plat "
-            source tests/test_manylinux_utils_docker.sh
-            source tests/test_library_builders.sh
-        "
+        build_multilinux $my_plat "source tests/test_manylinux_utils_docker.sh"
+        build_multilinux $my_plat "source tests/test_library_builders.sh"
         build_multilinux $my_plat "pip install simplejson"
         CONFIG_PATH=tests/config.sh
     fi


### PR DESCRIPTION
The change from #288 stopped `tests/test_library_builders.sh` from being run in some jobs.

As a demonstration, search for 'build_openssl' or 'build_libpng' in these Travis jobs.

Before #288 - https://travis-ci.org/github/matthew-brett/multibuild/jobs/625060463
With #288 - https://travis-ci.org/github/matthew-brett/multibuild/jobs/625083468

This PR resolves that.