### PR TITLE
Only remove original wheel if new wheel is created

### DIFF
--- a/manylinux_utils.sh
+++ b/manylinux_utils.sh
@@ -16,9 +16,12 @@ function repair_wheelhouse {
         if [[ $whl == *none-any.whl ]]; then  # Pure Python wheel
             if [ "$in_dir" != "$out_dir" ]; then cp $whl $out_dir; fi
         else
+            wheel_count=$(find $out_dir -name *.whl | wc -l)
             auditwheel repair $whl -w $out_dir/
-            # Remove unfixed if writing into same directory
-            if [ "$in_dir" == "$out_dir" ]; then rm $whl; fi
+            if [[ $(find $out_dir -name *.whl | wc -l) -gt $wheel_count ]]; then
+                # Remove unfixed if writing into same directory
+                if [ "$in_dir" == "$out_dir" ]; then rm $whl; fi
+            fi
         fi
     done
     chmod -R a+rwX $out_dir


### PR DESCRIPTION
devel has started [failing.](https://travis-ci.org/github/radarhere/multibuild/jobs/718957967)

This PR changes `repair_wheelhouse` so that only removes the original if a new wheel is created.