### PR TITLE
Updated Travis job to a macOS supported by Homebrew

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,6 +96,7 @@ matrix:
         - MB_PYTHON_VERSION=3.7
         - VENV=venv
     - os: osx
+      osx_image: xcode10.2
       env:
         - MB_PYTHON_VERSION=3.7
         - VENV=venv


### PR DESCRIPTION
devel is currently failing - https://travis-ci.org/github/matthew-brett/multibuild/jobs/750719524 - because Homebrew no longer supports 10.13.

This PR updates Xcode for that job to 10.2, so that macOS is then 10.14 (see https://docs.travis-ci.com/user/reference/osx/#macos-version)