### PR TITLE
Fix untar for tar.xz files

### DIFF
--- a/common_utils.sh
+++ b/common_utils.sh
@@ -158,7 +158,7 @@ function untar {
         gz|tgz) tar -zxf $in_fname ;;
         bz2) tar -jxf $in_fname ;;
         zip) unzip -qq $in_fname ;;
-        xz) unxz -c $in_fname | tar -xf ;;
+        xz) unxz -c $in_fname | tar -xf - ;;
         *) echo Did not recognize extension $extension; exit 1 ;;
     esac
 }

--- a/tests/test_common_utils.sh
+++ b/tests/test_common_utils.sh
@@ -44,6 +44,9 @@ rm_mkdir tmp_dir
 [ -e tmp_dir/afile ] && ingest "tmp_dir/afile should have been deleted"
 rmdir tmp_dir
 
+fetch_unpack https://github.com/harfbuzz/harfbuzz/releases/download/2.7.4/harfbuzz-2.7.4.tar.xz
+[ -d harfbuzz-2.7.4 ] || ingest ".tar.xz should have been unpacked"
+
 # Test suppress command
 function bad_cmd {
     echo bad


### PR DESCRIPTION
Before (e.g. https://github.com/nulano/pillow-wheels/runs/1636520270?check_suite_focus=true#step:4:5732):
```
  gzip: stdin: not in gzip format
  tar: Child returned status 1
  tar: Error exit delayed from previous errors
```

After (e.g. https://github.com/nulano/pillow-wheels/runs/1636651814?check_suite_focus=true#step:4:5739):
- working as expected