### PR TITLE
Added IS_MACOS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -372,7 +372,7 @@ To use these scripts
   You also need this file to specify how to run your tests::
 
     # Define custom utilities
-    # Test for macOS with [ -n "$IS_OSX" ]
+    # Test for macOS with [ -n "$IS_MACOS" ]
 
     function pre_build {
         # Any stuff that you need to do before you start building the wheels

--- a/common_utils.sh
+++ b/common_utils.sh
@@ -22,7 +22,7 @@ GET_PIP_URL=https://bootstrap.pypa.io/get-pip.py
 # with, so it is passed in when calling "docker run" for tests.
 UNICODE_WIDTH=${UNICODE_WIDTH:-32}
 
-if [ $(uname) == "Darwin" ]; then IS_OSX=1; fi
+if [ $(uname) == "Darwin" ]; then IS_MACOS=1; IS_OSX=1; fi
 
 # Work round bug in travis xcode image described at
 # https://github.com/direnv/direnv/issues/210
@@ -164,7 +164,7 @@ function untar {
 }
 
 function install_rsync {
-    if [ -z "$IS_OSX" ]; then
+    if [ -z "$IS_MACOS" ]; then
         [[ $(type -P rsync) ]] || yum_install rsync
     fi
 }
@@ -441,7 +441,7 @@ function install_pypy {
 
     local version=$1
     case "$PLAT" in
-    "x86_64")  if [ -n "$IS_OSX" ]; then
+    "x86_64")  if [ -n "$IS_MACOS" ]; then
                    suffix="osx64";
                else
                    suffix="linux64";

--- a/configure_build.sh
+++ b/configure_build.sh
@@ -1,5 +1,5 @@
 # Find, load common utilities
-# Defines IS_OSX, fetch_unpack
+# Defines IS_MACOS, fetch_unpack
 MULTIBUILD_DIR=$(dirname "${BASH_SOURCE[0]}")
 source $MULTIBUILD_DIR/common_utils.sh
 
@@ -12,8 +12,8 @@ CONFIGURE_BUILD_SOURCED=1
 BUILD_PREFIX="${BUILD_PREFIX:-/usr/local}"
 MB_ML_VER=${MB_ML_VER:-1}
 
-# IS_OSX is defined in common_utils.sh
-if [ -n "$IS_OSX" ]; then
+# IS_MACOS is defined in common_utils.sh
+if [ -n "$IS_MACOS" ]; then
     # Default compilation flags for OSX
     source $MULTIBUILD_DIR/osx_utils.sh
     PLAT=${PLAT:-$(macpython_arch_for_version $MB_PYTHON_VERSION)}

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -117,7 +117,7 @@ function openblas_get {
 
 function build_openblas {
     if [ -e openblas-stamp ]; then return; fi
-    if [ -n "$IS_OSX" ]; then
+    if [ -n "$IS_MACOS" ]; then
         brew install openblas
         brew link --force openblas
     else
@@ -131,7 +131,7 @@ function build_openblas {
 
 function build_zlib {
     # Gives an old but safe version
-    if [ -n "$IS_OSX" ]; then return; fi  # OSX has zlib already
+    if [ -n "$IS_MACOS" ]; then return; fi  # OSX has zlib already
     if [ -e zlib-stamp ]; then return; fi
     yum_install zlib-devel
     touch zlib-stamp
@@ -159,7 +159,7 @@ function build_libpng {
 }
 
 function build_bzip2 {
-    if [ -n "$IS_OSX" ]; then return; fi  # OSX has bzip2 libs already
+    if [ -n "$IS_MACOS" ]; then return; fi  # OSX has bzip2 libs already
     if [ -e bzip2-stamp ]; then return; fi
     fetch_unpack https://sourceware.org/pub/bzip2/bzip2-${BZIP2_VERSION}.tar.gz
     (cd bzip2-${BZIP2_VERSION} \
@@ -178,7 +178,7 @@ function build_tiff {
 function get_modern_cmake {
     # Install cmake >= 2.8
     local cmake=cmake
-    if [ -n "$IS_OSX" ]; then
+    if [ -n "$IS_MACOS" ]; then
         brew install cmake > /dev/null
     else
         if [ "`yum search cmake | grep ^cmake28\.`" ]; then
@@ -294,7 +294,7 @@ function build_blosc {
     (cd c-blosc-${BLOSC_VERSION} \
         && $cmake -DCMAKE_INSTALL_PREFIX=$BUILD_PREFIX . \
         && make install)
-    if [ -n "$IS_OSX" ]; then
+    if [ -n "$IS_MACOS" ]; then
         # Fix blosc library id bug
         for lib in $(ls ${BUILD_PREFIX}/lib/libblosc*.dylib); do
             install_name_tool -id $lib $lib
@@ -324,7 +324,7 @@ function build_lzf {
 function build_curl {
     if [ -e curl-stamp ]; then return; fi
     local flags="--prefix=$BUILD_PREFIX"
-    if [ -n "$IS_OSX" ]; then
+    if [ -n "$IS_MACOS" ]; then
         flags="$flags --with-darwinssl"
     else  # manylinux
         flags="$flags --with-ssl"
@@ -332,7 +332,7 @@ function build_curl {
     fi
     fetch_unpack https://curl.haxx.se/download/curl-${CURL_VERSION}.tar.gz
     (cd curl-${CURL_VERSION} \
-        && if [ -z "$IS_OSX" ]; then \
+        && if [ -z "$IS_MACOS" ]; then \
         LIBS=-ldl ./configure $flags; else \
         ./configure $flags; fi\
         && make -j4 \
@@ -346,7 +346,7 @@ function check_sha256sum {
     local sha256=$2
     if [ -z "$sha256" ]; then echo "Need SHA256 hash"; exit 1; fi
     echo "${sha256}  ${fname}" > ${fname}.sha256
-    if [ -n "$IS_OSX" ]; then
+    if [ -n "$IS_MACOS" ]; then
         shasum -a 256 -c ${fname}.sha256
     else
         sha256sum -c ${fname}.sha256
@@ -383,7 +383,7 @@ function build_pcre {
 
 function build_swig {
     if [ -e swig-stamp ]; then return; fi
-    if [ -n "$IS_OSX" ]; then
+    if [ -n "$IS_MACOS" ]; then
         brew install swig > /dev/null
     else
         build_pcre
@@ -394,7 +394,7 @@ function build_swig {
 
 function build_suitesparse {
     if [ -e suitesparse-stamp ]; then return; fi
-    if [ -n "$IS_OSX" ]; then
+    if [ -n "$IS_MACOS" ]; then
         brew install suite-sparse > /dev/null
     else
         yum_install suitesparse-devel > /dev/null
@@ -408,7 +408,7 @@ function build_libtool {
 
 function build_ragel {
     local htprefix=https
-    if [ -n "$IS_OSX" ]; then
+    if [ -n "$IS_MACOS" ]; then
         # Invalid certificate, when using macOS curl.
         # https://security.stackexchange.com/questions/232445/https-connection-to-specific-sites-fail-with-curl-on-macos
         # Cert will likely be removed by Safari update in due course.
@@ -481,7 +481,7 @@ function build_fftw {
 
 function build_cfitsio {
     if [ -e cfitsio-stamp ]; then return; fi
-    if [ -n "$IS_OSX" ]; then
+    if [ -n "$IS_MACOS" ]; then
         brew install cfitsio
     else
         # cannot use build_simple because cfitsio has no dash between name and version

--- a/tests/test_library_builders.sh
+++ b/tests/test_library_builders.sh
@@ -3,7 +3,7 @@
 # The environment
 uname -a
 
-if [ -n "$IS_OSX" ]; then
+if [ -n "$IS_MACOS" ]; then
     # Building on macOS
     export BUILD_PREFIX="${PWD}/builds"
     rm_mkdir $BUILD_PREFIX
@@ -43,14 +43,14 @@ suppress build_lcms2
 suppress ensure_xz
 suppress build_freetype
 suppress build_libyaml
-if [ -z "$IS_OSX" ]; then
+if [ -z "$IS_MACOS" ]; then
     # Gives compiler conformance error on macOS Sierra:
     # https://gist.github.com/5e20e137ea51fa8ca9fc443191f9d463
     # https://gist.github.com/ad86c474f3c0b7ec74290bb13f9414af
     suppress build_lzo
 fi
 suppress build_ragel
-if [ -z "$IS_OSX" ]; then
+if [ -z "$IS_MACOS" ]; then
     # already installed in the macOS image, so `brew install cfitsio` fails
     suppress build_cfitsio
 fi

--- a/tests/test_multibuild.sh
+++ b/tests/test_multibuild.sh
@@ -16,7 +16,7 @@ source tests/test_fill_submodule.sh
 # make sure it is set via one of the mechanisms above
 unset PYTHON_EXE
 
-if [ -n "$IS_OSX" ]; then
+if [ -n "$IS_MACOS" ]; then
     source osx_utils.sh
     MB_PYTHON_OSX_VER=${MB_PYTHON_OSX_VER:-$(macpython_sdk_for_version $MB_PYTHON_VERSION)}
     PLAT=${PLAT:-$(macpython_arch_for_version $MB_PYTHON_VERSION)}
@@ -32,7 +32,7 @@ else
 fi
 if [ -n "$TEST_BUILDS" ]; then
     MB_PYTHON_VERSION=${MB_PYTHON_VERSION:-3.7}
-    if [ -n "$IS_OSX" ]; then
+    if [ -n "$IS_MACOS" ]; then
         # This checked in test_library_builders.
         # Will be set automatically by docker call in build_multilinux below.
         PYTHON_VERSION=${MB_PYTHON_VERSION}


### PR DESCRIPTION
Apple left 'OS X' behind with 10.11, and now we've moved on to 11.

So multibuild's variable `IS_OSX` is not quite as suitable as it once was.

This PR adds `IS_MACOS` - but still sets `IS_OSX` to not break any external scripts that may be using it.