### PR TITLE
MRG: Use back-compatble pip versions for old Python

### DIFF
--- a/common_utils.sh
+++ b/common_utils.sh
@@ -14,6 +14,8 @@ set -e
 MULTIBUILD_DIR=$(dirname "${BASH_SOURCE[0]}")
 DOWNLOADS_SDIR=downloads
 PYPY_URL=https://downloads.python.org/pypy
+# For back-compatibility.  We use the "ensurepip" module now
+# instead of get-pip.py
 GET_PIP_URL=https://bootstrap.pypa.io/get-pip.py
 
 # Unicode width, default 32. Used here and in travis_linux_steps.sh
@@ -542,6 +544,9 @@ retry () {
 
 function install_pip {
     # Generic install pip
+    echo "Deprecated - please see pip installs within the individual"
+    echo "install functions for each Python type."
+    echo "Multibuild itself no longer uses this function."
     # Gets needed version from version implied by $PYTHON_EXE
     # Installs pip into python given by $PYTHON_EXE
     # Assumes pip will be installed into same directory as $PYTHON_EXE

--- a/docker_build_wrap.sh
+++ b/docker_build_wrap.sh
@@ -41,7 +41,9 @@ else
   PYTHON_EXE=$(cpython_path $PYTHON_VERSION $UNICODE_WIDTH)/bin/python
   ls $(dirname $PYTHON_EXE)
   export PATH="$(dirname $PYTHON_EXE):$PATH"
-  install_pip
+  # We can assume ensurepip is available and up to date.
+  $PYTHON_EXE -m ensurepip
+  PIP_CMD="$PYTHON_EXE -m pip"
 fi
 
 # Configuration for this package, possibly overriding `build_wheel` defined in

--- a/osx_utils.sh
+++ b/osx_utils.sh
@@ -383,10 +383,17 @@ function get_macpython_environment {
 
     remove_travis_ve_pip
     install_macpython $version $py_osx_ver
-    # Assume ensurepip available.
-    $PYTHON_EXE -m ensurepip
     PIP_CMD="$PYTHON_EXE -m pip"
-    $PIP_CMD install --upgrade pip
+    # Python 3.5 no longer compatible with latest pip
+    if [ "$(get_py_mm)" == "3.5" ]; then
+        # https://stackoverflow.com/a/29751768/1939576
+        curl -LO https://bootstrap.pypa.io/3.5/get-pip.py
+        $PYTHON_EXE get-pip.py
+        rm get-pip.py
+    else
+        $PYTHON_EXE -m ensurepip
+        $PIP_CMD install --upgrade pip
+    fi
 
     if [ -n "$venv_dir" ]; then
         install_virtualenv

--- a/osx_utils.sh
+++ b/osx_utils.sh
@@ -8,7 +8,6 @@ source $MULTIBUILD_DIR/common_utils.sh
 
 MACPYTHON_URL=https://www.python.org/ftp/python
 MACPYTHON_PY_PREFIX=/Library/Frameworks/Python.framework/Versions
-GET_PIP_URL=https://bootstrap.pypa.io/get-pip.py
 WORKING_SDIR=working
 
 # As of 22 December 2020 - latest Python of each version with binary download
@@ -384,7 +383,10 @@ function get_macpython_environment {
 
     remove_travis_ve_pip
     install_macpython $version $py_osx_ver
-    install_pip
+    # Assume ensurepip available.
+    $PYTHON_EXE -m ensurepip
+    PIP_CMD="$PYTHON_EXE -m pip"
+    $PIP_CMD install --upgrade pip
 
     if [ -n "$venv_dir" ]; then
         install_virtualenv

--- a/tests/test_python_install.sh
+++ b/tests/test_python_install.sh
@@ -55,15 +55,15 @@ else # not virtualenv
     if [[ $requested_impl == 'cp' ]]; then
         macpie_bin="$MACPYTHON_PY_PREFIX/$python_mm/bin"
         bin_name="python$python_mm"
-    else
+    else  # pypy
         macpie_bin="$PWD/pypy$python_mm-v$implementer_version-osx64/bin"
         bin_name="pypy"
     fi
     if [ "$PYTHON_EXE" != "$macpie_bin/$bin_name" ]; then
         ingest "Wrong macpython python cmd '$PYTHON_EXE'"
     fi
-    if [ "$PIP_CMD" != "sudo $macpie_bin/pip${python_mm}${expected_pip_args}" ]; then
-        ingest "Wrong macpython pip '$PIP_CMD'"
+    if [ "$PIP_CMD" != "$PYTHON_EXE -m pip" ]; then
+        ingest "Wrong macpython or pypy pip '$PIP_CMD'"
     fi
 fi
 


### PR DESCRIPTION
Python 2.7 went into pip back-compat mode.