### PR TITLE
Do not test build_openblas on manylinux_2_24

### DIFF
--- a/tests/test_library_builders.sh
+++ b/tests/test_library_builders.sh
@@ -37,7 +37,9 @@ suppress build_swig
     build_github wbhart/mpir mpir-3.0.0
     )
 suppress build_flex
-suppress build_openblas
+if [[ $MB_ML_VER != "_2_24" ]]; then
+    suppress build_openblas
+fi
 suppress build_tiff
 suppress build_lcms2
 suppress ensure_xz


### PR DESCRIPTION
Since manylinux_2_24 wheels are still unavailable at https://anaconda.org/multibuild-wheels-staging/openblas-libs/files

Previously discussed in https://github.com/matthew-brett/multibuild/pull/396#issuecomment-813307265