### PR TITLE
Fix failing trusty job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
   include:
     - os: linux
       dist: trusty
+      language: python
     # 64-bit builds
     - os: linux
       dist: xenial

--- a/tests/test_supported_wheels.sh
+++ b/tests/test_supported_wheels.sh
@@ -1,7 +1,7 @@
 # Test supported wheels script
 PYTHON_EXE=${PYTHON_EXE:-python}
 if [ -z "$PIP_CMD" ]; then
-    pip_install="$PYTHON_EXE -m pip install --user"
+    pip_install="$PYTHON_EXE -m pip install"
 else
     pip_install="$PIP_CMD install"
 fi


### PR DESCRIPTION
The trusty job is currently failing in devel - https://travis-ci.org/github/matthew-brett/multibuild/jobs/766300691

Runing Python 2.7.6, it would be failing because of https://github.com/pypa/pypi-support/issues/978. The issue suggests upgrading to workaround the problem. This PR does so by specifying `language: python` in the job.

That leads to a different error - "Can not perform a '--user' install. User site-packages are not visible in this virtualenv."

So I have then remove "--user" from the pip install command.