### PR TITLE
Fixed untar for .xz

### DIFF
--- a/common_utils.sh
+++ b/common_utils.sh
@@ -200,7 +200,7 @@ function untar {
         gz|tgz) tar -zxf $in_fname ;;
         bz2) tar -jxf $in_fname ;;
         zip) unzip -qq $in_fname ;;
-        xz) unxz -c $in_fname | tar -xf ;;
+        xz) unxz -c $in_fname | tar -xf - ;;
         *) echo Did not recognize extension $extension; exit 1 ;;
     esac
 }

--- a/common_utils.sh
+++ b/common_utils.sh
@@ -200,7 +200,11 @@ function untar {
         gz|tgz) tar -zxf $in_fname ;;
         bz2) tar -jxf $in_fname ;;
         zip) unzip -qq $in_fname ;;
-        xz) unxz -c $in_fname | tar -xf - ;;
+        xz) if [ -n "$IS_MACOS" ]; then
+              tar -xf $in_fname
+            else
+              unxz -c $in_fname | tar -xf -
+            fi ;;
         *) echo Did not recognize extension $extension; exit 1 ;;
     esac
 }

--- a/common_utils.sh
+++ b/common_utils.sh
@@ -203,6 +203,9 @@ function untar {
         xz) if [ -n "$IS_MACOS" ]; then
               tar -xf $in_fname
             else
+              if [[ ! $(type -P "unxz") ]]; then
+                echo xz must be installed to uncompress file; exit 1
+              fi
               unxz -c $in_fname | tar -xf -
             fi ;;
         *) echo Did not recognize extension $extension; exit 1 ;;
@@ -237,6 +240,12 @@ function fetch_unpack {
     if [ -z "$url" ];then echo "url not defined"; exit 1; fi
     local archive_fname=${2:-$(basename $url)}
     local arch_sdir="${ARCHIVE_SDIR:-archives}"
+    if [ -z "$IS_MACOS" ]; then
+        local extension=${archive_fname##*.}
+        if [ "$extension" == "xz" ]; then
+            ensure_xz
+        fi
+    fi
     # Make the archive directory in case it doesn't exist
     mkdir -p $arch_sdir
     local out_archive="${arch_sdir}/${archive_fname}"

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -237,7 +237,11 @@ function build_xz {
 
 function ensure_xz {
 	if [[ ! $(type -P "xz") ]]; then
-		build_xz
+	    if [ -n "$IS_MACOS" ]; then
+	        brew install xz
+	    else
+	        build_xz
+	    fi
 	fi
 }
 

--- a/tests/test_common_utils.sh
+++ b/tests/test_common_utils.sh
@@ -44,9 +44,6 @@ rm_mkdir tmp_dir
 [ -e tmp_dir/afile ] && ingest "tmp_dir/afile should have been deleted"
 rmdir tmp_dir
 
-fetch_unpack https://github.com/harfbuzz/harfbuzz/releases/download/2.7.4/harfbuzz-2.7.4.tar.xz
-[ -d harfbuzz-2.7.4 ] || ingest ".tar.xz should have been unpacked"
-
 # Test suppress command
 function bad_cmd {
     echo bad

--- a/tests/test_common_utils.sh
+++ b/tests/test_common_utils.sh
@@ -44,6 +44,9 @@ rm_mkdir tmp_dir
 [ -e tmp_dir/afile ] && ingest "tmp_dir/afile should have been deleted"
 rmdir tmp_dir
 
+fetch_unpack https://github.com/harfbuzz/harfbuzz/releases/download/2.7.4/harfbuzz-2.7.4.tar.xz
+[ -d harfbuzz-2.7.4 ] || ingest ".tar.xz should have been unpacked"
+
 # Test suppress command
 function bad_cmd {
     echo bad

--- a/tests/test_library_builders.sh
+++ b/tests/test_library_builders.sh
@@ -21,6 +21,9 @@ source tests/utils.sh
 
 start_spinner
 
+fetch_unpack https://github.com/harfbuzz/harfbuzz/releases/download/2.7.4/harfbuzz-2.7.4.tar.xz
+[ -d harfbuzz-2.7.4 ] || ingest ".tar.xz should have been unpacked"
+
 suppress build_bzip2
 suppress build_openssl
 suppress build_libpng


### PR DESCRIPTION
Continuation of #380

As established that PR, [`unxz -c $in_fname | tar -xf -`](https://github.com/radarhere/multibuild/commit/8d400c0356cc), passes [on Linux, but fails on macOS](https://travis-ci.org/github/radarhere/multibuild/builds/771016908).

[As has been pointed out](https://github.com/matthew-brett/multibuild/pull/380#discussion_r554427716), a simpler option would be [`tar -xf $in_fname`](https://github.com/radarhere/multibuild/commit/1bc54c77e29a335b3c010d7f8608b7c85a8fa25b), which passes with my test [on both Linux and macOS.](https://travis-ci.org/github/radarhere/multibuild/builds/771017020)

If I [move my test into test_library_builders.sh though](https://github.com/radarhere/multibuild/commit/d7f1f44a4f659970f5cf0e82f4faecf33e927a5d), so that it is run within [`build_multilinux`](https://github.com/matthew-brett/multibuild/blob/45d97819e7d39dd2264b2c3cd353c26c4e1ebb74/tests/test_multibuild.sh#L54), it [no longer passes](https://travis-ci.org/github/radarhere/multibuild/builds/771017119). Even if I run [`ensure_xz`](https://github.com/radarhere/multibuild/commit/fba52a86864db6da08fcd30d328a89397f407ee0) first, it [still fails](https://travis-ci.org/github/radarhere/multibuild/builds/771020299). None of that affects macOS though, so "tar -xf" is the simpler option on macOS.

Moving back to [`unxz -c $in_fname | tar -xf -`](https://github.com/radarhere/multibuild/commit/93c7938fe336d9a661126406fb02910362ff1994) on Linux with my test in test_library_builders.sh, I get ["unxz: command not found"](https://travis-ci.org/github/radarhere/multibuild/builds/771017211). So I have set `fetch_unpack` to run `ensure_xz` for .xz files.