### PR TITLE
Updated Python versions

### DIFF
--- a/osx_utils.sh
+++ b/osx_utils.sh
@@ -10,15 +10,15 @@ MACPYTHON_URL=https://www.python.org/ftp/python
 MACPYTHON_PY_PREFIX=/Library/Frameworks/Python.framework/Versions
 WORKING_SDIR=working
 
-# As of 5 April 2021 - latest Python of each version with binary download
+# As of 18 May 2021 - latest Python of each version with binary download
 # available.
 # See: https://www.python.org/downloads/mac-osx/
 LATEST_2p7=2.7.18
 LATEST_3p5=3.5.4
 LATEST_3p6=3.6.8
 LATEST_3p7=3.7.9
-LATEST_3p8=3.8.9
-LATEST_3p9=3.9.4
+LATEST_3p8=3.8.10
+LATEST_3p9=3.9.5
 
 
 function check_python {

--- a/tests/test_python_install.sh
+++ b/tests/test_python_install.sh
@@ -8,7 +8,7 @@ echo "virtualenv cmd: $VIRTUALENV_CMD"
 
 # Check that a pip install puts scripts on path
 # (Need setuptools >= 25.0.1 for delocate install).
-pip install "setuptools>=25"
+$PIP_CMD install "setuptools>=25"
 install_delocate
 delocate-listdeps --version || ingest "Delocate not installed right"
 


### PR DESCRIPTION
You can see that there are two jobs failing in the first commit, where I just upgrade the Python versions. The error is ["The 'pip==19.3.1' distribution was not found and is required by the application"](https://travis-ci.org/github/matthew-brett/multibuild/jobs/771532262#L712).

I conclude that this is because there hasn't been a pip release since the release of these Python versions. This means that [pip isn't newly installed](https://travis-ci.org/github/matthew-brett/multibuild/jobs/771532262#L673-L674), meaning that ``pip install "setuptools>=25" `` doesn't have the global link to pip in the same way.

So instead, I've changed the first line of
https://github.com/matthew-brett/multibuild/blob/45d97819e7d39dd2264b2c3cd353c26c4e1ebb74/tests/test_python_install.sh#L11-L12
to use ``$PIP_CMD``. This makes sense to me regardless, because it then mirrors ``install_delocate``.

https://github.com/matthew-brett/multibuild/blob/45d97819e7d39dd2264b2c3cd353c26c4e1ebb74/osx_utils.sh#L419-L422