### PR TITLE
Corrected README formatting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Uploads to Anaconda
 
 If you want to upload to Anaconda, and you don't need the extra storage space for nightly builds that Anaconda kindly donates to Numpy, Scipy etc, then you can do this with your own Anaconda organization.
 
-See `https://github.com/MacPython/nipy-wheels`_ for a simple example.
+See https://github.com/MacPython/nipy-wheels for a simple example.
 
 * Make an account at Anaconda.org.
 * Make an organization - for example we have used ``nipy``.
@@ -71,7 +71,7 @@ See `https://github.com/MacPython/nipy-wheels`_ for a simple example.
    ``wheelhouse/*.whl`` defines the files you want to upload.
 
 *   You might also want to build and upload from Appveyor.  To encrypt the API
-    key above, go to `https://ci.appveyor.com/account/matthew-brett/settings`_
+    key above, go to https://ci.appveyor.com/account/matthew-brett/settings
     (where ``matthew-brett`` is the account from which your Appveyor job runs.
     Click on "Encrypt YaML" on the left.  Type in your API key value (e.g.
     ``ni-1234abcd-12ab-34dc-1234-d1e1f3a4b5c6``) as the value to encrypt. Click "Encrypt" and note the text it suggests.  Now, at the top of your ``appveyor.yml`` file, add something like::
@@ -95,7 +95,7 @@ See `https://github.com/MacPython/nipy-wheels`_ for a simple example.
     where ``nipy\dist\*.whl`` finds the files you want to upload.
 
 There's a simple example of these steps applied at
-`https://github.com/MacPython/nipy-wheels`_.
+https://github.com/MacPython/nipy-wheels.
 
 Here is the NumPy code (for running on Travis CI) to upload to Anaconda:
 https://github.com/MacPython/numpy-wheels/blob/master/.travis.yml#L99


### PR DESCRIPTION
Corrects three instances in the README where links are not rendering as intended.

<img width="544" alt="Screen Shot 2021-07-05 at 5 10 44 pm" src="https://user-images.githubusercontent.com/3112309/124431676-01dc5200-ddb4-11eb-9832-d9ddff201f92.png">
<img width="687" alt="Screen Shot 2021-07-05 at 5 10 35 pm" src="https://user-images.githubusercontent.com/3112309/124431681-030d7f00-ddb4-11eb-88b4-9db8238abc75.png">
<img width="738" alt="Screen Shot 2021-07-05 at 5 10 40 pm" src="https://user-images.githubusercontent.com/3112309/124431686-043eac00-ddb4-11eb-8335-da1646778e0c.png">