### PR TITLE
ENH: Pass ENV_VARS_PATH to install_run

### DIFF
--- a/docker_test_wrap.sh
+++ b/docker_test_wrap.sh
@@ -22,5 +22,7 @@ cd /io
 # `config.sh` must define `run_tests` if using the default `install_run`.
 CONFIG_PATH=${CONFIG_PATH:-config.sh}
 source "$CONFIG_PATH"
+ENV_VARS_PATH=${ENV_VARS_PATH:-env_vars.sh}
+if [ -r "$ENV_VARS_PATH" ]; then source "$ENV_VARS_PATH"; fi
 
 install_run

--- a/travis_linux_steps.sh
+++ b/travis_linux_steps.sh
@@ -133,6 +133,7 @@ function install_run {
         -e MB_PYTHON_VERSION="$MB_PYTHON_VERSION" \
         -e UNICODE_WIDTH="$UNICODE_WIDTH" \
         -e CONFIG_PATH="$CONFIG_PATH" \
+        -e ENV_VARS_PATH="$ENV_VARS_PATH" \
         -e WHEEL_SDIR="$WHEEL_SDIR" \
         -e MANYLINUX_URL="$MANYLINUX_URL" \
         -e TEST_DEPENDS="$TEST_DEPENDS" \


### PR DESCRIPTION
NumPy needs that so that a check on the bundled OpenBLAS
library linkage can be run and checked for ILP64.