### PR TITLE
Updated default manylinux version to 2014

### DIFF
--- a/common_utils.sh
+++ b/common_utils.sh
@@ -24,6 +24,9 @@ GET_PIP_URL=https://bootstrap.pypa.io/get-pip.py
 # with, so it is passed in when calling "docker run" for tests.
 UNICODE_WIDTH=${UNICODE_WIDTH:-32}
 
+# Default Manylinux version
+MB_ML_VER=${MB_ML_VER:-2014}
+
 if [ $(uname) == "Darwin" ]; then
   IS_MACOS=1; IS_OSX=1;
 else

--- a/configure_build.sh
+++ b/configure_build.sh
@@ -10,7 +10,7 @@ fi
 CONFIGURE_BUILD_SOURCED=1
 
 BUILD_PREFIX="${BUILD_PREFIX:-/usr/local}"
-MB_ML_VER=${MB_ML_VER:-1}
+MB_ML_VER=${MB_ML_VER:-2014}
 
 # IS_MACOS is defined in common_utils.sh
 if [ -n "$IS_MACOS" ]; then

--- a/configure_build.sh
+++ b/configure_build.sh
@@ -10,7 +10,6 @@ fi
 CONFIGURE_BUILD_SOURCED=1
 
 BUILD_PREFIX="${BUILD_PREFIX:-/usr/local}"
-MB_ML_VER=${MB_ML_VER:-2014}
 
 # IS_MACOS is defined in common_utils.sh
 if [ -n "$IS_MACOS" ]; then

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -99,7 +99,7 @@ function openblas_get {
     # qual could be 64 to get a 64-bit version
     local qual=$2
     local prefix=openblas${qual}-v$OPENBLAS_VERSION
-    local manylinux=manylinux${MB_ML_VER:-1}
+    local manylinux=manylinux${MB_ML_VER:-2014}
     local fname="$prefix-${manylinux}_${plat}.tar.gz"
     local out_fname="${ARCHIVE_SDIR}/$fname"
     if [ ! -e "$out_fname" ]; then

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -99,7 +99,7 @@ function openblas_get {
     # qual could be 64 to get a 64-bit version
     local qual=$2
     local prefix=openblas${qual}-v$OPENBLAS_VERSION
-    local manylinux=manylinux${MB_ML_VER:-2014}
+    local manylinux=manylinux${MB_ML_VER}
     local fname="$prefix-${manylinux}_${plat}.tar.gz"
     local out_fname="${ARCHIVE_SDIR}/$fname"
     if [ ! -e "$out_fname" ]; then

--- a/travis_linux_steps.sh
+++ b/travis_linux_steps.sh
@@ -11,11 +11,6 @@
 #  install_run
 set -e
 
-# Default Manylinux version
-# Warning: ignored if DOCKER_IMAGE variable is set.
-# See build_multilinux function.
-MB_ML_VER=${MB_ML_VER:-2014}
-
 # Get our own location on this filesystem
 MULTIBUILD_DIR=$(dirname "${BASH_SOURCE[0]}")
 

--- a/travis_linux_steps.sh
+++ b/travis_linux_steps.sh
@@ -14,7 +14,7 @@ set -e
 # Default Manylinux version
 # Warning: ignored if DOCKER_IMAGE variable is set.
 # See build_multilinux function.
-MB_ML_VER=${MB_ML_VER:-1}
+MB_ML_VER=${MB_ML_VER:-2014}
 
 # Get our own location on this filesystem
 MULTIBUILD_DIR=$(dirname "${BASH_SOURCE[0]}")


### PR DESCRIPTION
Given that manylinux1 and manylinux2010 are EOL, this PR suggests updating the default to 2014.

https://github.com/pypa/manylinux
- manylinux2014 (CentOS 7 based)
...
- manylinux2010 (CentOS 6 based - EOL)
...
- manylinux1 (CentOS 5 based - EOL)
...
Support for manylinux1 will end on January 1st, 2022.